### PR TITLE
xapian-core : version bump

### DIFF
--- a/programming/misc/xapian-core/pspec.xml
+++ b/programming/misc/xapian-core/pspec.xml
@@ -13,7 +13,7 @@
         <IsA>app:console</IsA>
         <Summary>Probabilistic Information Retrieval library</Summary>
         <Description>Xapian is an Open Source Probabilistic Information Retrieval Library. It offers a highly adaptable toolkit that allows developers to easily add advanced indexing and search facilities to applications.</Description>
-        <Archive sha1sum="38c93710d586a2d8b8b870fbef25013387aea244" type="tarxz">https://oligarchy.co.uk/xapian/1.4.7/xapian-core-1.4.7.tar.xz</Archive>
+        <Archive sha1sum="17527a8bfa8254d3755b4b482157c245f33ea53d" type="tarxz">https://oligarchy.co.uk/xapian/1.4.14/xapian-core-1.4.14.tar.xz</Archive>
         <BuildDependencies>
             <Dependency>zlib-devel</Dependency>
             <Dependency>libutil-linux-devel</Dependency>
@@ -69,6 +69,13 @@
     </Package>
 
     <History>
+        <Update release="6">
+            <Date>2019-12-08</Date>
+            <Version>1.4.14</Version>
+            <Comment>Version bump.</Comment>
+            <Name>Blue Devil</Name>
+            <Email>bluedevil@sctzine.com</Email>
+        </Update>
         <Update release="5">
             <Date>2018-09-09</Date>
             <Version>1.4.7</Version>


### PR DESCRIPTION
checkelf doesnt detect runtime dependencies, in spite of that i didn't touch them. because, maybe pisilinux admins know that package needs those dependencies!