### PR TITLE
Fix dependencies for flatpak

### DIFF
--- a/hardware/virtualization/flatpak/pspec.xml
+++ b/hardware/virtualization/flatpak/pspec.xml
@@ -106,7 +106,7 @@
         <Update release="11">
             <Date>2021-04-06</Date>
             <Version>1.6.3</Version>
-            <Comment>Add gnupg dependency.</Comment>
+            <Comment>Update dependencies.</Comment>
             <Name>Berkan Şahin</Name>
             <Email>cicektaksi@tutanota.com</Email>
         </Update>

--- a/hardware/virtualization/flatpak/pspec.xml
+++ b/hardware/virtualization/flatpak/pspec.xml
@@ -42,6 +42,7 @@
             <Dependency>fuse</Dependency>
             <Dependency>glib2</Dependency>
             <Dependency>gpgme</Dependency>
+            <Dependency>gnupg</Dependency>
             <Dependency>libXau</Dependency> 
             <Dependency>libxml2</Dependency>
             <Dependency>libsoup</Dependency>
@@ -102,6 +103,13 @@
     </Package>
 
     <History>
+        <Update release="11">
+            <Date>2021-04-06</Date>
+            <Version>1.6.3</Version>
+            <Comment>Add gnupg dependency.</Comment>
+            <Name>Berkan Şahin</Name>
+            <Email>cicektaksi@tutanota.com</Email>
+        </Update>
         <Update release="10">
             <Date>2020-04-02</Date>
             <Version>1.6.3</Version>

--- a/hardware/virtualization/flatpak/pspec.xml
+++ b/hardware/virtualization/flatpak/pspec.xml
@@ -17,7 +17,7 @@
             <Dependency>util-linux</Dependency>
             <Dependency>gtk-doc</Dependency>
             <Dependency>libcap-devel</Dependency>
-            <Dependency versionFrom="0.3.3">bubblewrap</Dependency>
+            <Dependency versionFrom="0.4.0">bubblewrap</Dependency>
             <Dependency>polkit-devel</Dependency>
             <Dependency>libseccomp-devel</Dependency>
             <Dependency>dbus-devel</Dependency>

--- a/hardware/virtualization/flatpak/pspec.xml
+++ b/hardware/virtualization/flatpak/pspec.xml
@@ -38,7 +38,7 @@
         <Name>flatpak</Name>
         <RuntimeDependencies>
             <Dependency>xorg-app</Dependency>
-            <Dependency versionFrom="0.3.3">bubblewrap</Dependency>
+            <Dependency versionFrom="0.4.0">bubblewrap</Dependency>
             <Dependency>fuse</Dependency>
             <Dependency>glib2</Dependency>
             <Dependency>gpgme</Dependency>


### PR DESCRIPTION
Added gnupg as a runtime dependency and bumped bubblewrap version to 0.4.0 (otherwise the configuration step failed).

Resolves #9213 