### PR TITLE
Updated libical to 3.0.9 and gsettings-desktop-schemas to 3.38.0

### DIFF
--- a/desktop/gnome/base/gsettings-desktop-schemas/actions.py
+++ b/desktop/gnome/base/gsettings-desktop-schemas/actions.py
@@ -1,26 +1,21 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# Licensed under the GNU General Public License, version 3.
-# See the file http://www.gnu.org/licenses/gpl.txt
+# Licensed under the GNU General Public License, version 2
+# See the file http://www.gnu.org/copyleft/gpl.txt
 
+from pisi.actionsapi import get
 from pisi.actionsapi import autotools
 from pisi.actionsapi import pisitools
 from pisi.actionsapi import shelltools
-from pisi.actionsapi import get
+from pisi.actionsapi import mesontools
 
 def setup():
-    shelltools.makedirs("build")
-    shelltools.cd("build")
-    shelltools.system("meson .. --prefix=/usr")
-    
+    mesontools.configure()
+
 def build():
-    shelltools.cd("build")
-    shelltools.system("ninja")
-    
+    mesontools.build
+
 def install():
-    shelltools.cd("build")
-    shelltools.system("DESTDIR=%s ninja install" % get.installDIR())
-     
-    shelltools.cd("..")
-    pisitools.dodoc("COPYING", "NEWS", "README")
+    mesontools.install()
+    pisitools.dodoc("AUTHORS", "ChangeLog", "COPYING", "NEWS", "README", "MAINTAINERS")

--- a/desktop/gnome/base/gsettings-desktop-schemas/pspec.xml
+++ b/desktop/gnome/base/gsettings-desktop-schemas/pspec.xml
@@ -5,36 +5,39 @@
         <Name>gsettings-desktop-schemas</Name>
         <Homepage>https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas</Homepage>
         <Packager>
-            <Name>PisiLinux Community</Name>
-            <Email>admin@pisilinux.org</Email>
+            <Name>Berk Çakar</Name>
+            <Email>berk2238@hotmail.com</Email>
         </Packager>
-        <License>GPLv2</License>
-        <Isa>data</Isa>
-        <Summary>Collection of GSettings schemas for GNOME desktop</Summary>
-        <Description>Gsettings-desktop-schemas contains a collection of GSettings schemas for settings shared by various components of a desktop.</Description>
-        <Archive sha1sum="3702d1557b7dd1ac7f6236e2a6f7eeb0c906a9ae" type="tarxz">ftp://ftp.gnome.org/pub/gnome/sources/gsettings-desktop-schemas/3.34/gsettings-desktop-schemas-3.34.0.tar.xz</Archive>
+        <License>LGPLv2.1</License>
+        <PartOf>desktop.gnome</PartOf>
+        <Summary>gsettings-desktop-schemas contains a collection of GSettings schemas for
+settings shared by various components of a desktop.</Summary>
+        <Description>gsettings-desktop-schemas contains a collection of GSettings schemas for settings shared by various components of a desktop.</Description>
         <BuildDependencies>
-            <Dependency>meson</Dependency>
-            <Dependency>intltool</Dependency>
-            <Dependency>glib2-devel</Dependency>
-            <Dependency>gobject-introspection-devel</Dependency>
+            <Dependency versionFrom="2.66.2">glib2</Dependency>
+            <Dependency versionFrom="2.66.2">glib2-devel</Dependency>
+            <Dependency versionFrom="1.66.1">gobject-introspection</Dependency>
+            <Dependency versionFrom="1.66.1">gobject-introspection-devel</Dependency>
         </BuildDependencies>
+        <Archive sha1sum="3a78c37fc91975a8fb700de36cb28c8fc21d576e" type="tarxz">https://download.gnome.org/sources/gsettings-desktop-schemas/3.38/gsettings-desktop-schemas-3.38.0.tar.xz</Archive>
     </Source>
-
     <Package>
         <Name>gsettings-desktop-schemas</Name>
+        <Summary>gsettings-desktop-schemas contains a collection of GSettings schemas for
+settings shared by various components of a desktop.</Summary>
         <Files>
-            <Path fileType="doc">/usr/share/doc</Path>
-            <Path fileType="data">/usr/share/locale</Path>
-            <Path fileType="data">/usr/share/GConf/</Path>
-            <Path fileType="data">/usr/share/gir-1.0</Path>
             <Path fileType="library">/usr/lib/girepository-1.0</Path>
+            <Path fileType="data">/usr/share/GConf/</Path>
+            <Path fileType="doc">/usr/share/doc</Path>
+            <Path fileType="data">/usr/share/gir-1.0</Path>
             <Path fileType="localedata">/usr/share/glib-2.0/schemas</Path>
+            <Path fileType="data">/usr/share/locale</Path>
         </Files>
     </Package>
-
     <Package>
         <Name>gsettings-desktop-schemas-devel</Name>
+        <Summary>gsettings-desktop-schemas contains a collection of GSettings schemas for
+settings shared by various components of a desktop.</Summary>
         <RuntimeDependencies>
             <Dependency release="current">gsettings-desktop-schemas</Dependency>
         </RuntimeDependencies>
@@ -43,35 +46,13 @@
             <Path fileType="data">/usr/share/pkgconfig/</Path>
         </Files>
     </Package>
-
     <History>
-        <Update release="4">
-            <Date>2020-01-31</Date>
-            <Version>3.34.0</Version>
-            <Comment>Version bump.</Comment>
-            <Name>Mustafa Cinasal</Name>
-            <Email>muscnsl@gmail.com</Email>
-        </Update>
-        <Update release="3">
-            <Date>2019-11-23</Date>
-            <Version>3.34.0</Version>
-            <Comment>Version bump.</Comment>
-            <Name>Mustafa Cinasal</Name>
-            <Email>muscnsl@gmail.com</Email>
-        </Update>
-        <Update release="2">
-            <Date>2019-07-13</Date>
-            <Version>3.33.1</Version>
-            <Comment>version bump</Comment>
-            <Name>Erkan IŞIK</Name>
-            <Email>erkanisik@pisilinux.org</Email>
-        </Update>
         <Update release="1">
-            <Date>2018-12-03</Date>
-            <Version>3.10.1</Version>
-            <Comment>First Release</Comment>
-            <Name>Kamil Atlı</Name>
-            <Email>suvari@pisilinux.org</Email>
+            <Date>2021-04-06</Date>
+            <Version>3.38.0</Version>
+            <Comment>First release for Pisi Linux</Comment>
+            <Name>Berk Çakar</Name>
+            <Email>berk2238@hotmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/desktop/gnome/base/gsettings-desktop-schemas/pspec.xml
+++ b/desktop/gnome/base/gsettings-desktop-schemas/pspec.xml
@@ -47,12 +47,40 @@ settings shared by various components of a desktop.</Summary>
         </Files>
     </Package>
     <History>
-        <Update release="1">
+        <Update release="5">
             <Date>2021-04-06</Date>
             <Version>3.38.0</Version>
-            <Comment>First release for Pisi Linux</Comment>
+            <Comment>Version bump</Comment>
             <Name>Berk Çakar</Name>
             <Email>berk2238@hotmail.com</Email>
         </Update>
+         <Update release="4">
+             <Date>2020-01-31</Date>
+             <Version>3.34.0</Version>
+             <Comment>Version bump.</Comment>
+             <Name>Mustafa Cinasal</Name>
+             <Email>muscnsl@gmail.com</Email>
+         </Update>
+         <Update release="3">
+             <Date>2019-11-23</Date>
+             <Version>3.34.0</Version>
+             <Comment>Version bump.</Comment>
+             <Name>Mustafa Cinasal</Name>
+             <Email>muscnsl@gmail.com</Email>
+         </Update>
+         <Update release="2">
+             <Date>2019-07-13</Date>
+             <Version>3.33.1</Version>
+             <Comment>version bump</Comment>
+             <Name>Erkan IŞIK</Name>
+             <Email>erkanisik@pisilinux.org</Email>
+         </Update>
+         <Update release="1">
+             <Date>2018-12-03</Date>
+             <Version>3.10.1</Version>
+             <Comment>First Release</Comment>
+             <Name>Kamil Atlı</Name>
+             <Email>suvari@pisilinux.org</Email>
+         </Update>
     </History>
 </PISI>

--- a/programming/misc/libical/actions.py
+++ b/programming/misc/libical/actions.py
@@ -8,13 +8,15 @@ from pisi.actionsapi import cmaketools
 from pisi.actionsapi import pisitools
 
 def setup():
-    cmaketools.configure("-DCMAKE_INSTALL_PREFIX=/usr \
-                          -DCMAKE_INSTALL_LIBDIR=/usr/lib")
+    cmaketools.configure("-DCMAKE_INSTALL_PREFIX=/usr  \
+                          -DCMAKE_BUILD_TYPE=Release   \
+                          -DSHARED_ONLY=yes            \
+                          -DICAL_BUILD_DOCS=true       \
+                          -DGOBJECT_INTROSPECTION=true \
+                          -DICAL_GLIB_VAPI=true")
 
 def build():
     cmaketools.make()
 
 def install():
     cmaketools.install()
-    
-    

--- a/programming/misc/libical/pspec.xml
+++ b/programming/misc/libical/pspec.xml
@@ -5,82 +5,82 @@
         <Name>libical</Name>
         <Homepage>https://github.com/libical/libical</Homepage>
         <Packager>
-            <Name>PisiLinux Community</Name>
-            <Email>admins@pisilinux.org</Email>
+            <Name>Berk Çakar</Name>
+            <Email>berk2238@hotmail.com</Email>
         </Packager>
         <License>MPL-1.1</License>
         <License>LGPLv2</License>
         <IsA>library</IsA>
         <Summary>An open source reference implementation of the icalendar data type and serialization format</Summary>
         <Description>libical is an Open Source implementation of the IETF's iCalendar Calendaring and Scheduling protocols. (RFC 2445, 2446, and 2447). It parses iCal components and provides a C API for manipulating the component properties, parameters, and subcomponents.</Description>
-        <Archive sha1sum="6cffa9c188ee4bde003f2279d37ba2e68163fd7a" type="targz">https://github.com/libical/libical/releases/download/v3.0.7/libical-3.0.7.tar.gz</Archive>
         <BuildDependencies>
             <Dependency>cmake</Dependency>
-            <Dependency>perl</Dependency>
-            <Dependency>doxygen</Dependency>
-            <Dependency>docbook-xsl</Dependency>
-            <Dependency>gtk-doc</Dependency>
             <Dependency>db-devel</Dependency>
+            <Dependency>docbook-xsl</Dependency>
+            <Dependency>doxygen</Dependency>
             <Dependency>glib2-devel</Dependency>
+            <Dependency>gobject-introspection-devel</Dependency>
+            <Dependency>gtk-doc</Dependency>
             <Dependency>libxml2-devel</Dependency>
             <Dependency>libxslt-devel</Dependency>
+            <Dependency>perl</Dependency>
             <Dependency>python-six</Dependency>
-            <Dependency>gobject-introspection-devel</Dependency>
+            <Dependency>vala</Dependency>
         </BuildDependencies>
+        <Archive sha1sum="2b0eb28c1ad215bfb6c4f7c25249f6f2864976a7" type="targz">https://github.com/libical/libical/releases/download/v3.0.9/libical-3.0.9.tar.gz</Archive>
     </Source>
-
     <Package>
         <Name>libical</Name>
+        <Summary>The Evolution Data Server package provides a unified backend for programs that work with
+contacts, tasks, and calendar information.</Summary>
         <RuntimeDependencies>
             <Dependency>db</Dependency>
-            <Dependency>icu4c</Dependency>
             <Dependency>glib2</Dependency>
+            <Dependency>icu4c</Dependency>
             <Dependency>libgcc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib</Path>
+            <Path fileType="data">/usr/share/gir-1.0/*</Path>
             <Path fileType="data">/usr/share/libical/zoneinfo</Path>
+            <Path fileType="data">/usr/share/vala/*</Path>
         </Files>
     </Package>
-
     <Package>
         <Name>libical-devel</Name>
         <Summary>Development files for libical</Summary>
         <RuntimeDependencies>
-            <Dependency release="current">libical</Dependency>
             <Dependency>db-devel</Dependency>
-            <Dependency>icu4c-devel</Dependency>
             <Dependency>glib2-devel</Dependency>
+            <Dependency>icu4c-devel</Dependency>
+            <Dependency release="current">libical</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include</Path>
             <Path fileType="data">/usr/lib/pkgconfig</Path>
         </Files>
     </Package>
-    
     <Package>
         <Name>libical-docs</Name>
-        <IsA>data:doc</IsA>
         <Summary>libical reference documents</Summary>
         <Files>
             <Path fileType="data">/usr/share/gtk-doc</Path>
         </Files>
     </Package>
-
     <History>
+        <Update release="7">
+            <Date>2021-04-10</Date>
+            <Version>3.0.9</Version>
+            <Comment>Version bump</Comment>
+            <Name>Berk Çakar</Name>
+            <Email>berk2238@hotmail.com</Email>
+        </Update>
         <Update release="6">
             <Date>2020-01-14</Date>
             <Version>3.0.7</Version>
             <Comment>Version bump</Comment>
             <Name>İdris Kalp</Name>
             <Email>idriskalp@gmail.com</Email>
-        </Update>
-        <Update release="5">
-            <Date>2018-08-07</Date>
-            <Version>3.0.1</Version>
-            <Comment>Rebuild</Comment>
-            <Name>Mustafa Cinasal</Name>
-            <Email>admin@pisilinux.org</Email>
         </Update>
         <Update release="5">
             <Date>2018-01-31</Date>

--- a/programming/misc/libical/pspec.xml
+++ b/programming/misc/libical/pspec.xml
@@ -38,6 +38,7 @@ contacts, tasks, and calendar information.</Summary>
             <Dependency>glib2</Dependency>
             <Dependency>icu4c</Dependency>
             <Dependency>libgcc</Dependency>
+            <Dependency>gobject-introspection</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib</Path>


### PR DESCRIPTION
Those updates are required for Pisi Linux's Pantheon DE implementation.