### PR TITLE
v.bump

### DIFF
--- a/desktop/lxqt/featherpad/actions.py
+++ b/desktop/lxqt/featherpad/actions.py
@@ -12,9 +12,7 @@ def setup():
     shelltools.makedirs("build")
     shelltools.cd("build")
     cmaketools.configure("-DCMAKE_INSTALL_PREFIX=/usr \
-                          -DCMAKE_BUILD_TYPE=Release \
-                          -DCMAKE_INSTALL_LIBDIR=lib \
-                          -DPULL_TRANSLATIONS=yes", sourceDir="..")
+                          -DCMAKE_BUILD_TYPE=Release", sourceDir="..")
 def build():
     shelltools.cd("build")
     cmaketools.make()

--- a/desktop/lxqt/featherpad/pspec.xml
+++ b/desktop/lxqt/featherpad/pspec.xml
@@ -13,7 +13,7 @@
         <IsA>app:gui</IsA>
         <Summary>FeatherPad is a lightweight Qt5 plain-text editor for Linux</Summary>
         <Description>FeatherPad is a lightweight Qt5 plain-text editor for Linux</Description>
-        <Archive sha1sum="449a9ceb6e2d7a87a3131ceb35924ac719e50f08" type="targz">https://github.com/tsujan/FeatherPad/archive/V0.16.0.tar.gz</Archive>
+        <Archive sha1sum="3ffc0c4d3f28034d5238b58b4111857152ca4eab" type="targz">https://github.com/tsujan/FeatherPad/archive/V0.18.0.tar.gz</Archive>
         <BuildDependencies>
             <Dependency>extra-cmake-modules</Dependency>
             <Dependency>qt5-base-devel</Dependency>
@@ -47,6 +47,13 @@
     </Package>
 
     <History>
+        <Update release="6">
+            <Date>2021-04-26</Date>
+            <Version>0.18.0</Version>
+            <Comment>Version bump.</Comment>
+            <Name>Ayhan Yalçınsoy</Name>
+            <Email>ayhanyalcinsoy@pisilinux.org</Email>
+        </Update>
         <Update release="5">
             <Date>2020-11-05</Date>
             <Version>0.16.0</Version>

--- a/desktop/lxqt/menu-cache/actions.py
+++ b/desktop/lxqt/menu-cache/actions.py
@@ -11,7 +11,9 @@ from pisi.actionsapi import autotools
 
 def setup():
     shelltools.system("./autogen.sh")
-    autotools.configure("--disable-static")
+    autotools.configure("--disable-static \
+                         --libexecdir=/usr/lib \
+                         --sysconfdir=/etc")
 
 def build():
     autotools.make()

--- a/desktop/lxqt/menu-cache/files/menu-cache-1.1.0-0001-Support-gcc10-compilation.patch
+++ b/desktop/lxqt/menu-cache/files/menu-cache-1.1.0-0001-Support-gcc10-compilation.patch
@@ -1,0 +1,108 @@
+From 1ce739649b4d66339a03fc0ec9ee7a2f7c141780 Mon Sep 17 00:00:00 2001
+From: Mamoru TASAKA <mtasaka@fedoraproject.org>
+Date: Fri, 24 Jan 2020 13:33:00 +0900
+Subject: [PATCH] Support gcc10 compilation
+
+gcc10 now defaults to -fno-common, and with gcc10 menu-cache compilation fails like
+
+/bin/ld: menu-merge.o:menu-cache-gen/menu-tags.h:167: multiple definition of `DirDirs'; main.o:menu-cache-gen/menu-tags.h:167: first defined here
+/bin/ld: menu-merge.o:menu-cache-gen/menu-tags.h:164: multiple definition of `AppDirs'; main.o:menu-cache-gen/menu-tags.h:164: first defined here
+/bin/ld: menu-merge.o:menu-cache-gen/menu-tags.h:52: multiple definition of `menuTag_Layout'; main.o:menu-cache-gen/menu-tags.h:52: first defined here
+....
+
+This patch fixes compilation with gcc10: properly declaring variables in header with "extern", and also removing some unneeded variables in header files.
+---
+ menu-cache-gen/menu-tags.h | 55 ++++++++++++--------------------------
+ 1 file changed, 17 insertions(+), 38 deletions(-)
+
+diff --git a/menu-cache-gen/menu-tags.h b/menu-cache-gen/menu-tags.h
+index f3fd7d3..f71c0bc 100644
+--- a/menu-cache-gen/menu-tags.h
++++ b/menu-cache-gen/menu-tags.h
+@@ -22,38 +22,17 @@
+ #include <libfm/fm-extra.h>
+ #include <menu-cache.h>
+ 
+-FmXmlFileTag menuTag_Menu;
+-FmXmlFileTag menuTag_AppDir;
+-FmXmlFileTag menuTag_DefaultAppDirs;
+-FmXmlFileTag menuTag_DirectoryDir;
+-FmXmlFileTag menuTag_DefaultDirectoryDirs;
+-FmXmlFileTag menuTag_Include;
+-FmXmlFileTag menuTag_Exclude;
+-FmXmlFileTag menuTag_Filename;
+-FmXmlFileTag menuTag_Or;
+-FmXmlFileTag menuTag_And;
+-FmXmlFileTag menuTag_Not;
+-FmXmlFileTag menuTag_Category;
+-FmXmlFileTag menuTag_MergeFile;
+-FmXmlFileTag menuTag_MergeDir;
+-FmXmlFileTag menuTag_DefaultMergeDirs;
+-FmXmlFileTag menuTag_Directory;
+-FmXmlFileTag menuTag_Name;
+-FmXmlFileTag menuTag_Deleted;
+-FmXmlFileTag menuTag_NotDeleted;
+-FmXmlFileTag menuTag_OnlyUnallocated;
+-FmXmlFileTag menuTag_NotOnlyUnallocated;
+-FmXmlFileTag menuTag_All;
+-FmXmlFileTag menuTag_LegacyDir;
+-FmXmlFileTag menuTag_KDELegacyDirs;
+-FmXmlFileTag menuTag_Move;
+-FmXmlFileTag menuTag_Old;
+-FmXmlFileTag menuTag_New;
+-FmXmlFileTag menuTag_Layout;
+-FmXmlFileTag menuTag_DefaultLayout;
+-FmXmlFileTag menuTag_Menuname;
+-FmXmlFileTag menuTag_Separator;
+-FmXmlFileTag menuTag_Merge;
++extern FmXmlFileTag menuTag_AppDir;
++extern FmXmlFileTag menuTag_DirectoryDir;
++extern FmXmlFileTag menuTag_Include;
++extern FmXmlFileTag menuTag_Exclude;
++extern FmXmlFileTag menuTag_Filename;
++extern FmXmlFileTag menuTag_Or;
++extern FmXmlFileTag menuTag_And;
++extern FmXmlFileTag menuTag_Not;
++extern FmXmlFileTag menuTag_Category;
++extern FmXmlFileTag menuTag_All;
++extern FmXmlFileTag menuTag_LegacyDir;
+ 
+ typedef enum {
+     MERGE_NONE, /* starting value */
+@@ -152,19 +131,19 @@ typedef struct {
+ } MenuRule;
+ 
+ /* requested language(s) */
+-char **languages;
++extern char **languages;
+ 
+ /* list of menu files to monitor */
+-GSList *MenuFiles;
++extern GSList *MenuFiles;
+ 
+ /* list of menu dirs to monitor */
+-GSList *MenuDirs;
++extern GSList *MenuDirs;
+ 
+ /* list of available app dirs */
+-GSList *AppDirs;
++extern GSList *AppDirs;
+ 
+ /* list of available dir dirs */
+-GSList *DirDirs;
++extern GSList *DirDirs;
+ 
+ /* parse and merge menu files */
+ MenuMenu *get_merged_menu(const char *file, FmXmlFile **xmlfile, GError **error);
+@@ -177,7 +156,7 @@ gboolean save_menu_cache(MenuMenu *layout, const char *menuname, const char *fil
+ void _free_layout_items(GList *data);
+ 
+ /* verbosity level */
+-gint verbose;
++extern gint verbose;
+ 
+ #define DBG if (verbose) g_debug
+ #define VDBG if (verbose > 1) g_debug
+-- 
+2.24.1
+

--- a/desktop/lxqt/menu-cache/pspec.xml
+++ b/desktop/lxqt/menu-cache/pspec.xml
@@ -18,8 +18,11 @@
             <Dependency>gtk-doc</Dependency>
             <Dependency>glib2-devel</Dependency>
             <Dependency>libfm-extra-devel</Dependency>
-            <Dependency versionFrom="5.14.2">qt5-base-devel</Dependency>
+            <Dependency versionFrom="5.15.2">qt5-base-devel</Dependency>
         </BuildDependencies>
+        <Patches>
+            <Patch>menu-cache-1.1.0-0001-Support-gcc10-compilation.patch</Patch>
+        </Patches>
     </Source>
     <Package>
         <Name>menu-cache</Name>
@@ -47,6 +50,13 @@
         </Files>
     </Package>
     <History>
+        <Update release="8">
+            <Date>2021-04-26</Date>
+            <Version>1.1.0</Version>
+            <Comment>fixed build for gcc10</Comment>
+            <Name>Ayhan Yalçınsoy</Name>
+            <Email>ayhanyalcinsoy@pisilinux.org</Email>
+        </Update>
         <Update release="7">
             <Date>2020-11-05</Date>
             <Version>1.1.0</Version>


### PR DESCRIPTION
menu-cache: fixed build for gcc10
featherpad:v.bump to 0.18