### PR TITLE
update

### DIFF
--- a/desktop/budgie/budgie-control-center/actions.py
+++ b/desktop/budgie/budgie-control-center/actions.py
@@ -7,7 +7,7 @@
 from pisi.actionsapi import mesontools, pisitools
 
 def setup():
-    mesontools.configure()
+    mesontools.configure("--libexecdir=/usr/lib")
 
 def build():
     mesontools.build()

--- a/desktop/budgie/budgie-control-center/pspec.xml
+++ b/desktop/budgie/budgie-control-center/pspec.xml
@@ -9,9 +9,10 @@
             <Email>admins@pisilinux.org</Email>
         </Packager>
         <License>GPLv2</License>
+        <Icon>budgie</Icon>
         <Summary>Budgie Control Center is a fork of GNOME Settings / GNOME Control Center</Summary>
         <Description>Budgie Control Center is a fork of GNOME Settings / GNOME Control Center with the intent of providing a simplified list of settings that are applicable to the Budgie 10 series</Description>
-	    <Archive sha1sum="4879a694488523d680f98e7270b98025d8748e25" type="tarxz">https://github.com/BuddiesOfBudgie/budgie-control-center/releases/download/v1.0.1/budgie-control-center-1.0.1.tar.xz</Archive>
+	    <Archive sha1sum="7ddc9a09b1b7e30320f9f9ca1d9fddd180292b2e" type="tarxz">https://github.com/BuddiesOfBudgie/budgie-control-center/releases/download/v1.0.2/budgie-control-center-1.0.2.tar.xz</Archive>
 	    <BuildDependencies>
             <Dependency>dbus-glib-devel</Dependency>
             <Dependency>gnome-desktop-devel</Dependency>
@@ -36,7 +37,7 @@
             <Dependency>libsecret-devel</Dependency>
             <Dependency>network-manager-applet</Dependency>
             <Dependency>libmm-glib-devel</Dependency>
-            <Dependency>gnome-bluetooth-devel</Dependency>
+            <Dependency>gnome-bluetooth3-devel</Dependency>
             <Dependency>libwacom-devel</Dependency>
             <Dependency>colord-gtk-devel</Dependency>
             <Dependency>libsoup-devel</Dependency>
@@ -73,7 +74,6 @@
             <Dependency>libnma</Dependency>
             <Dependency>polkit</Dependency>
             <Dependency>upower</Dependency>
-            <Dependency>fribidi</Dependency>
             <Dependency>libgtop</Dependency>
             <Dependency>libsoup</Dependency>
             <Dependency>libxml2</Dependency>
@@ -91,13 +91,14 @@
             <Dependency>gnome-desktop</Dependency>
             <Dependency>NetworkManager</Dependency>
             <Dependency>accountsservice</Dependency>
-            <Dependency>gnome-bluetooth</Dependency>
+            <Dependency>gnome-bluetooth3</Dependency>
             <Dependency>pulseaudio-libs</Dependency>
             <Dependency>gnome-online-accounts</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin</Path>
-            <Path fileType="executable">/usr/libexec</Path>
+            <Path fileType="executable">/usr/lib/budgie-cc-remote-login-helper</Path>
+            <Path fileType="executable">/usr/lib/budgie-control-center-print-renderer</Path>
             <Path fileType="library">/usr/lib/libhandy*</Path>
             <Path fileType="data">/usr/share/applications</Path>
             <Path fileType="data">/usr/share/bash-completion</Path>
@@ -116,6 +117,8 @@
 
    <Package>
         <Name>budgie-control-center-devel</Name>
+        <Summary>Development files for budgie-control-center</Summary>
+        <Icon>development</Icon>
         <RuntimeDependencies>
             <Dependency>gtk3-devel</Dependency>
             <Dependency release="current">budgie-control-center</Dependency>
@@ -128,6 +131,13 @@
     </Package>
 
     <History>
+        <Update release="2">
+            <Date>2022-06-03</Date>
+            <Version>1.0.2</Version>
+            <Comment>version bump</Comment>
+            <Name>Ayhan Yalçınsoy</Name>
+            <Email>ayhanyalcinsoy@pisilinux.org</Email>
+        </Update>
         <Update release="1">
             <Date>2022-04-28</Date>
             <Version>1.0.1</Version>

--- a/desktop/budgie/budgie-desktop/actions.py
+++ b/desktop/budgie/budgie-desktop/actions.py
@@ -10,7 +10,7 @@ from pisi.actionsapi import shelltools
 from pisi.actionsapi import get
 
 def setup():
-    mesontools.configure()
+    mesontools.configure("--libexec=/usr/lib")
 
 def build():
     mesontools.build()

--- a/desktop/budgie/budgie-desktop/pspec.xml
+++ b/desktop/budgie/budgie-desktop/pspec.xml
@@ -10,6 +10,7 @@
         </Packager>
         <License>GPLv2</License>
         <License>LGPLv2.1</License>
+        <Icon>budgie</Icon>
         <Summary>Modern desktop environment from the Solus Project.</Summary>
         <Description>Budgie is a desktop environment that uses GNOME technologies such as GTK3 and is developed by the Solus project.</Description>
 	    <Archive sha1sum="1ecc36ddc0f5c40ca7d1159dd49517e53683e11a" type="tarxz">https://github.com/BuddiesOfBudgie/budgie-desktop/releases/download/v10.6.1/budgie-desktop-v10.6.1.tar.xz</Archive>
@@ -35,11 +36,12 @@
             <Dependency>upower-devel</Dependency>
             <Dependency>gtk3-devel</Dependency>
             <Dependency>polkit-devel</Dependency>
-            <Dependency>gnome-bluetooth-devel</Dependency>
+            <Dependency>gnome-bluetooth3-devel</Dependency>
             <Dependency>gnome-menus-devel</Dependency>
             <Dependency>gnome-settings-daemon-devel</Dependency>
             <Dependency>meson</Dependency>
             <Dependency>mesa-devel</Dependency>
+            <Dependency>gnome-bluetooth-devel</Dependency>
         </BuildDependencies>
         <Patches>
             <!--Patch level="1">override-syntax.patch</Patch-->
@@ -66,7 +68,7 @@
             <Dependency>gnome-desktop</Dependency>
             <Dependency>libXcomposite</Dependency>
             <Dependency>libutil-linux</Dependency>
-            <Dependency>gnome-bluetooth</Dependency>
+            <Dependency>gnome-bluetooth3</Dependency>
             <Dependency>pulseaudio-libs</Dependency>
             <Dependency>gobject-introspection</Dependency>
         </RuntimeDependencies>
@@ -91,6 +93,8 @@
 
     <Package>
         <Name>budgie-desktop-devel</Name>
+        <Summary>Development files for budgie-desktop</Summary>
+        <Icon>development</Icon>
         <RuntimeDependencies>
             <Dependency release="current">budgie-desktop</Dependency>
             <Dependency>gtk3-devel</Dependency>

--- a/desktop/misc/lightdm/pspec.xml
+++ b/desktop/misc/lightdm/pspec.xml
@@ -10,6 +10,7 @@
         </Packager>
         <License>GPL2</License>
         <IsA>app</IsA>
+        <Icon>lightdm</Icon>
         <Summary>LightDM is a cross-desktop display manager.</Summary>
         <Description>LightDM is a cross-desktop display manager.</Description>
         <Archive type="tarxz" sha1sum="d91966f79f173825ac8bb51973842f9fb6c9ef1b">https://github.com/CanonicalLtd/lightdm/releases/download/1.30.0/lightdm-1.30.0.tar.xz</Archive>
@@ -49,6 +50,7 @@
         <RuntimeDependencies>
             <!--Dependency>pisi-lightdm-greeter</Dependency--> <!--çember lightdm-->
             <Dependency>pam</Dependency>
+            <Dependency>audit</Dependency>
             <Dependency>glib2</Dependency>
             <Dependency>libX11</Dependency>
             <Dependency>libxcb</Dependency>
@@ -88,6 +90,7 @@
 
     <Package>
         <Name>lightdm-devel</Name>
+        <Icon>development</Icon>
         <Summary>LightDM is a cross-desktop display manager.</Summary>
         <RuntimeDependencies>
             <Dependency release="current">lightdm</Dependency>
@@ -106,6 +109,7 @@
     <Package>
         <Name>liblightdm-qt5</Name>
         <Summary>Qt5 library for LightDM.</Summary>
+        <Icon>lightdm</Icon>
         <RuntimeDependencies>
             <Dependency>libgcc</Dependency>
             <Dependency>lightdm</Dependency>
@@ -119,6 +123,7 @@
     <Package>
         <Name>liblightdm-qt5-devel</Name>
         <Summary>LightDM is a cross-desktop display manager.</Summary>
+        <Icon>development</Icon>
         <RuntimeDependencies>
             <Dependency release="current">liblightdm-qt5</Dependency>
             <Dependency>qt5-base-devel</Dependency>
@@ -131,6 +136,13 @@
 
 
     <History>
+        <Update release="3">
+            <Date>2022-06-03</Date>
+            <Version>1.30.0</Version>
+            <Comment>Rebuild for qt5</Comment>
+            <Name>Ayhan Yalçınsoy</Name>
+            <Email>ayhanyalcinsoy@pisilinux.org</Email>
+        </Update>
         <Update release="2">
             <Date>2021-06-05</Date>
             <Version>1.30.0</Version>


### PR DESCRIPTION
budgie-control-center:v.bump to 1.0.2
budgie-dekstop:rebuild for gnome42
lightdm:rebuild for qt5