### PR TITLE
libmicrohttpd fixes

### DIFF
--- a/server/web/libmicrohttpd/actions.py
+++ b/server/web/libmicrohttpd/actions.py
@@ -9,14 +9,11 @@ from pisi.actionsapi import pisitools
 from pisi.actionsapi import get
 
 def setup():
-    autotools.autoreconf("-vfi")
     autotools.configure("--disable-static \
                          --enable-shared \
-                         --enable-curl \
-                         --enable-largefile \
-                         --enable-messages")
-    
-    pisitools.dosed("libtool", " -shared ", " -Wl,-O1,--as-needed -shared ")
+                         --disable-curl \
+                         --disable-examples \
+                         --enable-https")
 
 def build():
     autotools.make()

--- a/server/web/libmicrohttpd/pspec.xml
+++ b/server/web/libmicrohttpd/pspec.xml
@@ -8,16 +8,13 @@
             <Name>PisiLinux Community</Name>
             <Email>admins@pisilinux.org</Email>
         </Packager>
-        <License>LGPLv2</License>
+        <License>LGPLv2+</License>
         <IsA>library</IsA>
         <Summary>A compact API and implementation of HTTP web server</Summary>
         <Description>libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application.</Description>
         <Archive sha1sum="d835f399a42265f7759a462c22e57eee2300f708" type="targz">http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.77.tar.gz</Archive>
         <BuildDependencies>
-            <Dependency>texinfo</Dependency>
             <Dependency>gnutls-devel</Dependency>
-            <Dependency>libgcrypt-devel</Dependency>
-            <Dependency>libgpg-error-devel</Dependency>
         </BuildDependencies>
     </Source>
 
@@ -25,12 +22,8 @@
         <Name>libmicrohttpd</Name>
         <RuntimeDependencies>
             <Dependency>gnutls</Dependency>
-            <Dependency>libgcrypt</Dependency>
-            <Dependency>libgpg-error</Dependency>
         </RuntimeDependencies>
         <Files>
-            <Path fileType="executable">/usr/bin/microspdy2http</Path>
-            <Path fileType="executable">/usr/bin/demo</Path>
             <Path fileType="library">/usr/lib</Path>
             <Path fileType="man">/usr/share/man</Path>
             <Path fileType="info">/usr/share/info</Path>
@@ -56,6 +49,13 @@
     </Package>
 
     <History>
+        <Update release="7">
+            <Date>2023-05-31</Date>
+            <Version>0.9.77</Version>
+            <Comment>Package fixes.</Comment>
+            <Name>Evgeny Grin (Karlson2)</Name>
+            <Email>k2k@narod.ru</Email>
+        </Update>
         <Update release="6">
             <Date>2023-05-30</Date>
             <Version>0.9.77</Version>


### PR DESCRIPTION
* Removed "autoreconf". Upstream provides working 'configure'.
* Disabled libcurl in parameter. It is not declared as dependency and used only for testing.
* Disabled examples build. They are not needed for installed library.
* Enforced HTTPS version build, instead of automatic detection
* Removed unneeded libtool patch
* Fixed license (LGPLv2.1 or later)
* Removed "textinfo" dependency. It is not needed, all info files are pre-built.
* Removed "libgrypt" and "libgpg-error". They was needed for for GnuTLS >2.20
* Removed mention of "microspdy". It was removed several years ago from upstream.
* Removed "demo" file. It is compiled example, which is not designed for any practical use.