### PR TITLE
gnome-bluetooth3: fix pspec.xml syntax (per repology)

### DIFF
--- a/desktop/gnome/base/gnome-bluetooth3/pspec.xml
+++ b/desktop/gnome/base/gnome-bluetooth3/pspec.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" ?>
 <!DOCTYPE PISI SYSTEM "https://pisilinux.org/projeler/pisi/pisi-spec.dtd">
 <PISI>


### PR DESCRIPTION
Fix issue reported by repology (https://repology.org/repositories/updates) 

> 2023-08-05 07:44:02   desktop/gnome/base/gnome-bluetooth3/pspec.xml: ERROR: Cannot parse XML: XML or text declaration not at start of entity: line 2, column 0