### PR TITLE
qt5-gstreamer: fix pspec.xml syntax (per repology)

### DIFF
--- a/desktop/toolkit/qt5/qt5-gstreamer/pspec.xml
+++ b/desktop/toolkit/qt5/qt5-gstreamer/pspec.xml
@@ -1,4 +1,4 @@
- <?xml version="1.0" ?>
+<?xml version="1.0" ?>
 <!DOCTYPE PISI SYSTEM "https://pisilinux.org/projeler/pisi/pisi-spec.dtd">
 <PISI>
     <Source>


### PR DESCRIPTION
Fix issue reported by repology (https://repology.org/repositories/updates)

> desktop/toolkit/qt5/qt5-gstreamer/pspec.xml: ERROR: Cannot parse XML: XML or text declaration not at start of entity: line 1, column 1