### PR TITLE
chromium-browser: fix pspec.xml download URL schema (per repology)

### DIFF
--- a/network/web/chromium-browser/pspec.xml
+++ b/network/web/chromium-browser/pspec.xml
@@ -13,7 +13,7 @@
         <IsA>app:gui</IsA>
         <Summary>A WebKit powered web browser</Summary>
         <Description>Chromium-browser is an open-source web browser, powered by WebKit.</Description>
-        <Archive type="tarxz" sha1sum="f6aa2dceb42c7304f3435b3729d9956ee7dd198b">commondatastorage.googleapis.com/chromium-browser-official/chromium-103.0.5060.134.tar.xz</Archive>
+        <Archive type="tarxz" sha1sum="f6aa2dceb42c7304f3435b3729d9956ee7dd198b">https://commondatastorage.googleapis.com/chromium-browser-official/chromium-103.0.5060.134.tar.xz</Archive>
         <BuildDependencies>
             <Dependency>alsa-lib-devel</Dependency>
             <Dependency>at-spi2-atk-devel</Dependency>


### PR DESCRIPTION
Fix issue reported by repology (https://repology.org/repositories/updates)

> network/web/chromium-browser/pspec.xml: ERROR: download: "commondatastorage.googleapis.com/chromium-browser-official/chromium-103.0.5060.134.tar.xz" does not look like an URL (schema missing)