### PR TITLE
yali fix

### DIFF
--- a/system/installer/yali/pspec.xml
+++ b/system/installer/yali/pspec.xml
@@ -12,7 +12,7 @@
         <IsA>app:gui</IsA>
         <Summary>Yet Another Linux Installer</Summary>
         <Description>YALI is the graphical installer for PiSi Linux distribution which is written using the Qt framework.</Description>
-        <Archive sha1sum="c2744ac56bd11ff0b888be64bdcc3775549466d8" type="targz">https://github.com/pisilinux/yali/archive/refs/tags/v3.3.7.0.tar.gz</Archive>
+        <Archive sha1sum="ea073b42cafc782f8718da7757b614f9e5d03be4" type="targz">https://github.com/erkanisik1/yali/archive/refs/tags/v3.3.7.3.tar.gz</Archive>
         <BuildDependencies>
             <Dependency>python-qt5-devel</Dependency>
             <Dependency>python-devel</Dependency>
@@ -93,6 +93,13 @@
     </Package>
 
     <History>
+	<Update release="22">
+            <Date>2024-04-23</Date>
+            <Version>3.3.7.3</Version>
+            <Comment>Rebuild.</Comment>
+            <Name>Mustafa Cinasal</Name>
+            <Email>muscnsl@gmail.com</Email>
+        </Update>
         <Update release="21">
             <Date>2022-08-20</Date>
             <Version>3.3.7.0</Version>


### PR DESCRIPTION
dosyalar kopyalanırken bar haricinde hem dosya adı hemde % olarak gösteriliyordu % gösterimi kaldırıldı sadece bar ve dosya adı gösterimi yapıldı