### PR TITLE
Initial package releases for APFS stuff

### DIFF
--- a/kernel/drivers/module-linux-apfs-rw/actions.py
+++ b/kernel/drivers/module-linux-apfs-rw/actions.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Licensed under GNU General Public License, version 3.
+# See the file https://www.gnu.org/licenses/gpl.txt
+
+from pisi.actionsapi import kerneltools
+from pisi.actionsapi import autotools
+from pisi.actionsapi import pisitools
+
+KDIR = kerneltools.getKernelVersion()
+
+def build():
+    autotools.make()
+
+def install():
+    pisitools.insinto("/lib/modules/%s/extra" % KDIR, "*.ko")
+    pisitools.dodoc("LICENSE", "README*")

--- a/kernel/drivers/module-linux-apfs-rw/pspec.xml
+++ b/kernel/drivers/module-linux-apfs-rw/pspec.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "https://pisilinux.org/projeler/pisi/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>module-linux-apfs-rw</Name>
+        <Homepage>https://github.com/linux-apfs/linux-apfs-rw</Homepage>
+        <Packager>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Packager>
+        <License>GPLv2</License>
+        <IsA>driver</IsA>
+        <Summary>Experimental support for APFS</Summary>
+        <Description>The Apple File System (APFS) is the copy-on-write filesystem currently used on all Apple devices. This module provides a degree of experimental support on Linux.</Description>
+        <Archive sha1sum="df749e1810304783174bbccb5b0cb4f991c8299a" type="targz">https://github.com/linux-apfs/linux-apfs-rw/archive/refs/tags/v0.3.11.tar.gz</Archive>
+        <BuildDependencies>
+           <Dependency version="6.6.50">kernel-module-headers</Dependency>
+        </BuildDependencies>
+    </Source>
+
+    <Package>
+        <Name>module-linux-apfs-rw</Name>
+        <RuntimeDependencies>
+            <Dependency version="6.6.50">kernel</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="library" permanent="true">/lib/modules</Path>
+            <Path fileType="doc">/usr/share/doc</Path>
+        </Files>
+        <BuildFlags>
+            <Flag>noDelta</Flag>
+        </BuildFlags>
+    </Package>
+
+    <History>
+        <Update release="1">
+            <Date>2024-10-02</Date>
+            <Version>v0.3.11</Version>
+            <Comment>Initial build and release for kernel 6.6.50</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
+    </History>
+</PISI>

--- a/kernel/drivers/module-linux-apfs-rw/translations.xml
+++ b/kernel/drivers/module-linux-apfs-rw/translations.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<PISI>
+    <Source>
+        <Name>module-linux-apfs-rw</Name>
+        <Summary xml:lang="tr">APFS için deneysel destek</Summary>
+        <Description xml:lang="tr">Apple Dosya Sistemi (APFS), şu anda tüm Apple cihazlarında kullanılan bir yazarken-kopyala (Copy-on-Write/CoW) dosya sistemidir. Bu modül, Linux için bir düzeye kadar deneysel destek sağlar.</Description>
+    </Source>
+</PISI>

--- a/kernel/tools/apfsprogs/actions.py
+++ b/kernel/tools/apfsprogs/actions.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Licensed under GNU General Public License, version 3.
+# See the file https://www.gnu.org/licenses/gpl.txt
+
+from pisi.actionsapi import autotools
+from pisi.actionsapi import pisitools
+from pisi.actionsapi import shelltools
+from pisi.actionsapi import get
+
+MAKEFLAGS = 'GIT_COMMIT=f31d7c2 \
+             DESTDIR=%(prefix)s/%(defaultprefix)s' % {
+                                                         'prefix': get.installDIR(),
+                                                         'defaultprefix': get.defaultprefixDIR(),
+                                                     }
+
+def build():
+    autotools.make("-C lib")
+    autotools.make("-C apfs-label %s" % MAKEFLAGS)
+    autotools.make("-C apfs-snap %s" % MAKEFLAGS)
+    autotools.make("-C apfsck %s" % MAKEFLAGS)
+    autotools.make("-C mkapfs %s" % MAKEFLAGS)
+
+def install():
+    autotools.install("-C apfs-label %s" % MAKEFLAGS)
+    autotools.install("-C apfs-snap %s" % MAKEFLAGS)
+    autotools.install("-C apfsck %s" % MAKEFLAGS)
+    autotools.install("-C mkapfs %s" % MAKEFLAGS)
+
+    pisitools.dodoc("LICENSE", "README*")

--- a/kernel/tools/apfsprogs/pspec.xml
+++ b/kernel/tools/apfsprogs/pspec.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "https://pisilinux.org/projeler/pisi/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>apfsprogs</Name>
+        <Homepage>https://github.com/linux-apfs/apfsprogs</Homepage>
+        <Packager>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Packager>
+        <License>GPLv2</License>
+        <IsA>driver</IsA>
+        <Summary>Experimental APFS tools for Linux</Summary>
+        <Description>Apfsprogs is a suite of userspace utilities for working with the Apple File System on Linux. It's intended mainly to help test the Linux kernel module, located at https://github.com/linux-apfs/linux-apfs-rw.git</Description>
+        <Archive sha1sum="8e2d510109ac0a733f9e6c8941c467ffbd8cf3b3" type="targz">https://github.com/linux-apfs/apfsprogs/archive/f31d7c2.tar.gz</Archive>
+    </Source>
+
+    <Package>
+        <Name>apfsprogs</Name>
+        <RuntimeDependencies>
+            <Dependency>module-linux-apfs-rw</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="executable">/usr/bin</Path>
+            <Path fileType="man">/usr/share/man/man8</Path>
+            <Path fileType="doc">/usr/share/doc</Path>
+        </Files>
+        <BuildFlags>
+            <Flag>noDelta</Flag>
+        </BuildFlags>
+    </Package>
+
+    <History>
+        <Update release="1">
+            <Date>2024-10-03</Date>
+            <Version>0.1</Version>
+            <Comment>Initial build specs for PiSi.</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
+    </History>
+</PISI>

--- a/kernel/tools/apfsprogs/translations.xml
+++ b/kernel/tools/apfsprogs/translations.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<PISI>
+    <Source>
+        <Name>apfsprogs</Name>
+        <Summary xml:lang="tr">Linux için deneysel APFS araçları</Summary>
+        <Description xml:lang="tr">Apfsprogs, Apple Dosya Sistemi ile çalışmak için bir kullanıcı-alanı araç setidir. Genellikle https://github.com/linux-apfs/linux-apfs-rw.git adresinde yer alan Linux çekirdek modülünü test etmeye yardım etmek için geliştirilmiştir.</Description>
+    </Source>
+</PISI>


### PR DESCRIPTION
Includes spec files for linux-apfs-rw module and apfsprogs from
GitHub:linux-apfs.
