### PR TITLE
Fix links for various projects

### DIFF
--- a/desktop/kde/applications/akonadi-calendar-tools/pspec.xml
+++ b/desktop/kde/applications/akonadi-calendar-tools/pspec.xml
@@ -11,7 +11,7 @@
         <License>GPLv2</License>
         <Summary>CLI tools to manage akonadi calendars</Summary>
         <Description>CLI tools to manage akonadi calendars</Description>
-        <Archive sha1sum="f6437fdd39f68a1f3854461faba6165bc3392668" type="tarxz">http://download.kde.org/stable/release-service/23.08.5/src/akonadi-calendar-tools-23.08.5.tar.xz</Archive>
+        <Archive sha1sum="f6437fdd39f68a1f3854461faba6165bc3392668" type="tarxz">https://download.kde.org/stable/release-service/23.08.5/src/akonadi-calendar-tools-23.08.5.tar.xz</Archive>
         <BuildDependencies>
             <Dependency>boost-devel</Dependency>
             <Dependency versionFrom="23.08.5">akonadi-devel</Dependency>

--- a/desktop/kde/applications/akonadi-import-wizard/pspec.xml
+++ b/desktop/kde/applications/akonadi-import-wizard/pspec.xml
@@ -11,7 +11,7 @@
         <License>GPLv2</License>
         <Summary>CLI tools to manage akonadi calendars</Summary>
         <Description>Import data from other mail clients to KMail</Description>
-        <Archive sha1sum="38f85b72c6b4d36477bb0b2ea35699f02744cfd3" type="tarxz">http://download.kde.org/stable/release-service/23.08.5/src/akonadi-import-wizard-23.08.5.tar.xz</Archive>
+        <Archive sha1sum="38f85b72c6b4d36477bb0b2ea35699f02744cfd3" type="tarxz">https://download.kde.org/stable/release-service/23.08.5/src/akonadi-import-wizard-23.08.5.tar.xz</Archive>
         <BuildDependencies>
             <Dependency>boost-devel</Dependency>
             <Dependency versionFrom="23.08.5">akonadi-devel</Dependency>

--- a/desktop/kde/applications/akonadiconsole/pspec.xml
+++ b/desktop/kde/applications/akonadiconsole/pspec.xml
@@ -9,7 +9,7 @@
         <License>GPLv2</License>
         <Summary>Akonadi management and debugging console</Summary>
         <Description>Akonadi management and debugging console</Description>
-        <Archive type="tarxz" sha1sum="f10deced34be457dfda16d3cecbb490384869daa">http://download.kde.org/stable/release-service/23.08.5/src/akonadiconsole-23.08.5.tar.xz</Archive>
+        <Archive type="tarxz" sha1sum="f10deced34be457dfda16d3cecbb490384869daa">https://download.kde.org/stable/release-service/23.08.5/src/akonadiconsole-23.08.5.tar.xz</Archive>
         <BuildDependencies>
             <Dependency versionFrom="23.08.5">akonadi-contacts-devel</Dependency>
             <Dependency versionFrom="23.08.5">akonadi-devel</Dependency>

--- a/desktop/kde/applications/akregator/pspec.xml
+++ b/desktop/kde/applications/akregator/pspec.xml
@@ -11,7 +11,7 @@
         <License>GPLv2</License>
         <Summary>A KDE blogging client</Summary>
         <Description>Akregator helps you to keep informed about new stories on websites like KDE Dot News and Planet KDE blogs. The technology used is RSS and many sites support it.</Description>
-        <Archive sha1sum="8750c01d64e6f77d3a66578910de4812326516af" type="tarxz">http://download.kde.org/stable/release-service/23.08.5/src/akregator-23.08.5.tar.xz</Archive>
+        <Archive sha1sum="8750c01d64e6f77d3a66578910de4812326516af" type="tarxz">https://download.kde.org/stable/release-service/23.08.5/src/akregator-23.08.5.tar.xz</Archive>
         <BuildDependencies>
             <Dependency>boost-devel</Dependency>
             <Dependency>extra-cmake-modules</Dependency>

--- a/desktop/kde/applications/analitza/pspec.xml
+++ b/desktop/kde/applications/analitza/pspec.xml
@@ -3,7 +3,7 @@
 <PISI>
     <Source>
         <Name>analitza</Name>
-        <Homepage>https://projects.kde.org/projects/kde/kdeedu/analitza</Homepage>
+        <Homepage>https://invent.kde.org/education/analitza</Homepage>
         <Packager>
             <Name>PisiLinux Community</Name>
             <Email>admins@pisilinux.org</Email>

--- a/desktop/kde6/applications/akonadi-calendar-tools-kf6/pspec.xml
+++ b/desktop/kde6/applications/akonadi-calendar-tools-kf6/pspec.xml
@@ -11,7 +11,7 @@
         <License>GPLv2</License>
         <Summary>CLI tools to manage akonadi calendars</Summary>
         <Description>CLI tools to manage akonadi calendars</Description>
-        <Archive sha1sum="7ab20677a9db0a8e7e248e24300da6213fcf0e08" type="tarxz">http://download.kde.org/stable/release-service/24.08.2/src/akonadi-calendar-tools-24.08.2.tar.xz</Archive>
+        <Archive sha1sum="7ab20677a9db0a8e7e248e24300da6213fcf0e08" type="tarxz">https://download.kde.org/stable/release-service/24.08.2/src/akonadi-calendar-tools-24.08.2.tar.xz</Archive>
         <BuildDependencies>
             <Dependency>boost-devel</Dependency>
             <Dependency versionFrom="24.08.2">akonadi-kf6-devel</Dependency>

--- a/desktop/kde6/applications/akonadi-import-wizard-kf6/pspec.xml
+++ b/desktop/kde6/applications/akonadi-import-wizard-kf6/pspec.xml
@@ -11,7 +11,7 @@
         <License>GPLv2</License>
         <Summary>CLI tools to manage akonadi calendars</Summary>
         <Description>Import data from other mail clients to kmail-kf6</Description>
-        <Archive sha1sum="c689bb71a3715022675b2fd983852096414ce74d" type="tarxz">http://download.kde.org/stable/release-service/24.08.2/src/akonadi-import-wizard-24.08.2.tar.xz</Archive>
+        <Archive sha1sum="c689bb71a3715022675b2fd983852096414ce74d" type="tarxz">https://download.kde.org/stable/release-service/24.08.2/src/akonadi-import-wizard-24.08.2.tar.xz</Archive>
         <BuildDependencies>
             <Dependency>boost-devel</Dependency>
             <Dependency versionFrom="24.08.2">akonadi-kf6-devel</Dependency>

--- a/desktop/kde6/applications/akonadiconsole-kf6/pspec.xml
+++ b/desktop/kde6/applications/akonadiconsole-kf6/pspec.xml
@@ -9,7 +9,7 @@
         <License>GPLv2</License>
         <Summary>Akonadi management and debugging console</Summary>
         <Description>Akonadi management and debugging console</Description>
-        <Archive type="tarxz" sha1sum="64b4b2fc20ac777bc6c3564bdfda0b366cd05321">http://download.kde.org/stable/release-service/24.08.2/src/akonadiconsole-24.08.2.tar.xz</Archive>
+        <Archive type="tarxz" sha1sum="64b4b2fc20ac777bc6c3564bdfda0b366cd05321">https://download.kde.org/stable/release-service/24.08.2/src/akonadiconsole-24.08.2.tar.xz</Archive>
         <BuildDependencies>
             <Dependency versionFrom="24.08.2">akonadi-contacts-kf6-devel</Dependency>
             <Dependency versionFrom="24.08.2">akonadi-kf6-devel</Dependency>

--- a/desktop/kde6/applications/akregator-kf6/pspec.xml
+++ b/desktop/kde6/applications/akregator-kf6/pspec.xml
@@ -11,7 +11,7 @@
         <License>GPLv2</License>
         <Summary>A KDE blogging client</Summary>
         <Description>akregator-kf6 helps you to keep informed about new stories on websites like KDE Dot News and Planet KDE blogs. The technology used is RSS and many sites support it.</Description>
-        <Archive sha1sum="7dfe8e7812329c8aba29fb7ea7137d04cadeddaa" type="tarxz">http://download.kde.org/stable/release-service/24.08.2/src/akregator-24.08.2.tar.xz</Archive>
+        <Archive sha1sum="7dfe8e7812329c8aba29fb7ea7137d04cadeddaa" type="tarxz">https://download.kde.org/stable/release-service/24.08.2/src/akregator-24.08.2.tar.xz</Archive>
         <BuildDependencies>
             <Dependency>boost-devel</Dependency>
             <Dependency>extra-cmake-modules-kf6</Dependency>

--- a/desktop/kde6/applications/analitza-kf6/pspec.xml
+++ b/desktop/kde6/applications/analitza-kf6/pspec.xml
@@ -3,7 +3,7 @@
 <PISI>
     <Source>
         <Name>analitza-kf6</Name>
-        <Homepage>https://projects.kde.org/projects/kde/kdeedu/analitza-kf6</Homepage>
+        <Homepage>https://invent.kde.org/education/analitza</Homepage>
         <Packager>
             <Name>PisiLinux Community</Name>
             <Email>admins@pisilinux.org</Email>

--- a/game/arcade/abe/pspec.xml
+++ b/game/arcade/abe/pspec.xml
@@ -3,7 +3,7 @@
 <PISI>
     <Source>
         <Name>abe</Name>
-        <Homepage>http://abe.sourceforge.net/</Homepage>
+        <Homepage>https://abe.sourceforge.net/</Homepage>
         <Packager>
             <Name>PisiLinux Community</Name>
             <Email>admins@pisilinux.org</Email>

--- a/hardware/sound/alsa-plugins/pspec.xml
+++ b/hardware/sound/alsa-plugins/pspec.xml
@@ -14,7 +14,7 @@
 		<PartOf>multimedia.plugin</PartOf>
 		<Summary>The Advanced Linux Sound Architecture (ALSA) plugins.</Summary>
 		<Description>alsa-plugins provides plugins like JACK, PulseAudio, etc. for ALSA.</Description>
-		<Archive sha1sum="3f6863dfbb2e8ce7b1cda38e6d4db1cce1e07a5e" type="tarbz2">http://www.alsa-project.org/files/pub/plugins/alsa-plugins-1.2.12.tar.bz2</Archive>
+		<Archive sha1sum="3f6863dfbb2e8ce7b1cda38e6d4db1cce1e07a5e" type="tarbz2">https://www.alsa-project.org/files/pub/plugins/alsa-plugins-1.2.12.tar.bz2</Archive>
 		<BuildDependencies>
 			<Dependency>dbus-devel</Dependency>
 			<Dependency>ffmpeg-devel</Dependency>

--- a/multimedia/graphics/aalib/pspec.xml
+++ b/multimedia/graphics/aalib/pspec.xml
@@ -3,7 +3,7 @@
 <PISI>
     <Source>
         <Name>aalib</Name>
-        <Homepage>http://aa-project.sourceforge.net/aalib/</Homepage>
+        <Homepage>https://aa-project.sourceforge.net/aalib/</Homepage>
         <Packager>
             <Name>PisiLinux Community</Name>
             <Email>admins@pisilinux.org</Email>

--- a/multimedia/sound/ario/pspec.xml
+++ b/multimedia/sound/ario/pspec.xml
@@ -3,7 +3,7 @@
 <PISI>
 	<Source>
 		<Name>ario</Name>
-		<Homepage>http://ario-player.sourceforge.net/</Homepage>
+		<Homepage>https://ario-player.sourceforge.net/</Homepage>
 		<Packager>
 			<Name>Pisilinux Community</Name>
 			<Email>admins@pisilinux.org</Email>

--- a/network/plugin/flashplugin/pspec.xml
+++ b/network/plugin/flashplugin/pspec.xml
@@ -3,7 +3,7 @@
 <PISI>
     <Source>
         <Name>flashplugin</Name>
-        <Homepage>http://labs.adobe.com/technologies/flashplayer10</Homepage>
+        <Homepage>https://get.adobe.com/flashplayer/about</Homepage>
         <Packager>
             <Name>PisiLinux Community</Name>
             <Email>admins@pisilinux.org</Email>

--- a/programming/build/ant/pspec.xml
+++ b/programming/build/ant/pspec.xml
@@ -3,7 +3,7 @@
 <PISI>
     <Source>
         <Name>ant</Name>
-        <Homepage>http://ant.apache.org</Homepage>
+        <Homepage>https://ant.apache.org</Homepage>
         <Packager>
             <Name>PisiLinux Community</Name>
             <Email>admins@pisilinux.org</Email>
@@ -12,7 +12,7 @@
         <IsA>app:console</IsA>
         <Summary>Java-based build tool</Summary>
         <Description>Apache Ant is a Java-based build tool. In theory, it is kind of like Make, but without Make's wrinkles.</Description>
-        <Archive sha1sum="4b407594cef802268cca901578d929b3adb4d615" type="tarxz">http://archive.apache.org/dist/ant/source/apache-ant-1.10.14-src.tar.xz</Archive>
+        <Archive sha1sum="4b407594cef802268cca901578d929b3adb4d615" type="tarxz">https://archive.apache.org/dist/ant/source/apache-ant-1.10.14-src.tar.xz</Archive>
         <BuildDependencies>
             <Dependency>jdk8-openjdk</Dependency>
         </BuildDependencies>

--- a/programming/library/ada/pspec.xml
+++ b/programming/library/ada/pspec.xml
@@ -12,7 +12,7 @@
         <IsA>library</IsA>
         <Summary>Ada is a fast and spec-compliant URL parser written in C++.</Summary>
         <Description>Ada, C++ ile yazılmış, hızlı ve spesifikasyonlara uygun bir URL ayrıştırıcısıdır.</Description>
-        <Archive sha1sum="5add21611bb51c17922c4334d19971e003037658" type="targz">https://github-cdn.pages.dev/ada-url/ada/archive/refs/tags/v2.9.0.tar.gz</Archive>
+        <Archive sha1sum="78e92abdc3cfcd4e53f789721dfeefd52be4c151" type="targz">https://github.com/ada-url/ada/archive/refs/tags/v2.9.2.zip</Archive>
         <BuildDependencies>
             <Dependency>git</Dependency>
             <Dependency>cmake</Dependency>
@@ -54,6 +54,13 @@
     </Package>
 
     <History>
+        <Update release="2">
+            <Date>2024-10-03</Date>
+            <Version>2.9.2</Version>
+            <Comment>Uprev. See upstream changelog.</Comment>
+            <Name>Bedirhan KURT</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="1">
             <Date>2024-08-02</Date>
             <Version>2.9.0</Version>

--- a/programming/library/ada/pspec.xml
+++ b/programming/library/ada/pspec.xml
@@ -3,7 +3,7 @@
 <PISI>
     <Source>
         <Name>ada</Name>
-        <Homepage>https://github-cdn.pages.dev/ada-url/ada/</Homepage>
+        <Homepage>https://www.ada-url.com/</Homepage>
         <Packager>
             <Name>PisiLinux Community</Name>
             <Email>admins@pisilinux.org</Email>

--- a/programming/misc/apr-util/pspec.xml
+++ b/programming/misc/apr-util/pspec.xml
@@ -3,7 +3,7 @@
 <PISI>
     <Source>
         <Name>apr-util</Name>
-        <Homepage>http://apr.apache.org/</Homepage>
+        <Homepage>https://apr.apache.org/</Homepage>
         <Packager>
             <Name>PisiLinux Community</Name>
             <Email>admins@pisilinux.org</Email>

--- a/programming/misc/apr/pspec.xml
+++ b/programming/misc/apr/pspec.xml
@@ -3,7 +3,7 @@
 <PISI>
     <Source>
         <Name>apr</Name>
-        <Homepage>http://apr.apache.org/</Homepage>
+        <Homepage>https://apr.apache.org/</Homepage>
         <Packager>
             <Name>PisiLinux Community</Name>
             <Email>admins@pisilinux.org</Email>

--- a/server/web/apache/pspec.xml
+++ b/server/web/apache/pspec.xml
@@ -3,7 +3,7 @@
 <PISI>
     <Source>
         <Name>apache</Name>
-        <Homepage>http://httpd.apache.org/</Homepage>
+        <Homepage>https://httpd.apache.org/</Homepage>
         <Packager>
             <Name>Pisi Linux Admins</Name>
             <Email>admins@pisilinux.org</Email>

--- a/util/archive/areca/pspec.xml
+++ b/util/archive/areca/pspec.xml
@@ -3,7 +3,7 @@
 <PISI>
     <Source>
         <Name>areca</Name>
-        <Homepage>http://www.areca-backup.org/</Homepage>
+        <Homepage>https://www.areca-backup.org/</Homepage>
         <Packager>
             <Name>Pisi Linux Community</Name>
             <Email>admins@pisilinux.org</Email>


### PR DESCRIPTION
I just discovered the existence of Repology which basically shows you what package is up to date, which isn't; which repo has problems, etc.

This repository alone is noted to have [more than 1.2k outdated projects](https://repology.org/projects/?inrepo=pisi_main&outdated=1) and [156 potentially vulnerable ones](https://repology.org/projects/?inrepo=pisi_main&vulnerable=1).

There are also [a total of 672 known problems](https://repology.org/repository/pisi_main/problems) for packages in this repo, which is what this PR aims to fix.

It's a work in progress right now, and is very likely to stay that way for a while as I keep looking into this and fixing as many problems as I can.
