### PR TITLE
Tidbits for my personal use cases (not really)

### DIFF
--- a/kernel/tools/nvidia-prime/actions.py
+++ b/kernel/tools/nvidia-prime/actions.py
@@ -1,0 +1,10 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Licensed under GNU General Public License, version 3.
+# See the file https://www.gnu.org/licenses/gpl.txt
+
+from pisi.actionsapi import pisitools
+
+def install():
+    pisitools.dobin("prime-run")

--- a/kernel/tools/nvidia-prime/pspec.xml
+++ b/kernel/tools/nvidia-prime/pspec.xml
@@ -1,0 +1,41 @@
+<PISI>
+    <Source>
+        <Name>nvidia-prime</Name>
+        <Homepage>https://archlinux.org/packages/extra/any/nvidia-prime/</Homepage>
+        <Packager>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Packager>
+        <License>GPL</License>
+        <PartOf>kernel.tools</PartOf>
+        <Summary>NVIDIA Prime Render Offload configuration and utilities</Summary>
+        <Description>Coming from Arch Linux, nvidia-prime is a package that provides the prime-run script, which can later be combined with switcheroo-control, to launch programs using NVIDIA GPU, assuming the proprietary drivers are installed and configured properly.</Description>
+        <BuildDependencies>
+            <Dependency>bash</Dependency>
+        </BuildDependencies>
+        <Archive sha1sum="3b005e12d112154d3461b9c3036ffca7590acd30" type="binary">https://gitlab.archlinux.org/archlinux/packaging/packages/nvidia-prime/-/raw/main/prime-run</Archive>
+    </Source>
+    <Package>
+        <Name>nvidia-prime</Name>
+        <Summary>NVIDIA Prime Render Offload configuration and utilities</Summary>
+        <RuntimeDependencies>
+            <Dependency>bash</Dependency>
+            <AnyDependency>
+                <Dependency>module-nvidia-current</Dependency>
+                <Dependency>nvidia-current-dkms</Dependency>
+            </AnyDependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="executable">/usr/bin</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2024-10-20</Date>
+            <Version>1.0</Version>
+            <Comment>Initial Pisi Linux packaging for proposal</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
+    </History>
+</PISI>

--- a/kernel/tools/nvidia-prime/translations.xml
+++ b/kernel/tools/nvidia-prime/translations.xml
@@ -1,0 +1,7 @@
+<PISI>
+    <Source>
+        <Name>nvidia-prime</Name>
+        <Summary xml:lang="tr">NVIDIA Prime Render Boşaltma ayarlama ve araçları</Summary>
+        <Description xml:lang="tr">Arch Linux'tan gelen nvidia-prime, kapalı kaynak sürücülerin kurulu olduğunu varsayarsak, sonradan switcheroo-control ile kombine edilebilen ve programların NVIDIA ekran kartı üstünde çalıştırılmasını sağlayan prime-run betiğini sağlayan pakettir.</Description>
+    </Source>
+</PISI>

--- a/programming/language/go/pspec.xml
+++ b/programming/language/go/pspec.xml
@@ -13,10 +13,10 @@
         <IsA>app:console</IsA>
         <Summary>Compiler and tools for the Go programming language from Google</Summary>
         <Description>Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.</Description>
-        <Archive sha1sum="393c0d8224da8e6dcbf3367f6b9d240884c946ca" type="targz">https://github.com/golang/go/archive/refs/tags/go1.22.2.tar.gz</Archive>
+        <Archive sha1sum="19f1507e89f926c4d8edd97ca2c8b02158b3ebe8" type="targz">https://github.com/golang/go/archive/refs/tags/go1.23.2.tar.gz</Archive>
         <!--<Archive sha1sum="6ecdf5a03974462119c051a0d53f825c851ffdbe" type="tarbz2" target="go-go1.14.3">https://dev.gentoo.org/~williamh/dist/go-linux-amd64-bootstrap-1.13.6.tbz</Archive>-->
         <!-- for using as a bootstrap -->
-        <Archive sha1sum="d6727f9b11c80631773a993c9823e60634b138b4" type="targz" target="go-go1.22.2">https://go.dev/dl/go1.22.2.linux-amd64.tar.gz</Archive>
+        <Archive sha1sum="682ecb2fe66c54019f96eb81c4327bf278ce185d" type="targz" target="go-go1.23.2">https://go.dev/dl/go1.23.2.linux-amd64.tar.gz</Archive>
     </Source>
 
     <Package>
@@ -39,6 +39,13 @@
     </Package>
 
     <History>
+        <Update release="22">
+            <Date>2024-10-20</Date>
+            <Version>1.23.2</Version>
+            <Comment>Version bump</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="21">
             <Date>2024-05-02</Date>
             <Version>1.22.2</Version>

--- a/programming/scm/github-cli/actions.py
+++ b/programming/scm/github-cli/actions.py
@@ -11,10 +11,10 @@ from pisi.actionsapi import get
 def build():
     shelltools.system("go build \
         -trimpath \
-        -ldflags '-extldflags \"%s\" -X github.com/cli/cli/command.Version=v0.5.7 -X github.com/cli/cli/command.BuildDate=2020-02-24' \
+        -ldflags '-extldflags \"%s\" -X github.com/cli/cli/command.Version=v2.59.0 -X github.com/cli/cli/command.BuildDate=2024-10-20' \
         -o 'bin/gh' ./cmd/gh" % get.LDFLAGS())
 
 def install():
-    shelltools.cd("../cli-0.5.7")
+    shelltools.cd("../cli-2.59.0")
     pisitools.insinto("/usr/bin", "bin/gh")
     pisitools.dodoc("LICENSE", "README*")

--- a/programming/scm/github-cli/pspec.xml
+++ b/programming/scm/github-cli/pspec.xml
@@ -5,15 +5,15 @@
         <Name>github-cli</Name>
         <Homepage>https://github.com/cli/cli</Homepage>
         <Packager>
-            <Name>Blue Devil</Name>
-            <Email>bluedevil@sctzine.com</Email>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
         </Packager>
         <PartOf>programming.scm</PartOf>
         <License>MIT</License>
         <IsA>app:console</IsA>
-        <Summary>The GitHub CLI</Summary>
-        <Description>gh is GitHub on the command line, and it's now available in beta. It brings pull requests, issues, and other GitHub concepts to the terminal next to where you are already working with git and your code.</Description>
-        <Archive sha1sum="a649a97e57cab30c9a577fd1af43c435e8742bbd" type="targz">https://github.com/cli/cli/archive/v0.5.7.tar.gz</Archive>
+        <Summary>GitHub CLI</Summary>
+        <Description>"gh" is GitHub on the command line. It brings pull requests, issues, and other GitHub concepts to the terminal next to where you are already working with "git" and your code.</Description>
+        <Archive sha1sum="d0643e0651d0482ad6c78d7cb36743228af27d98" type="targz">https://github.com/cli/cli/archive/v2.59.0.tar.gz</Archive>
         <BuildDependencies>
             <Dependency>golang</Dependency>
         </BuildDependencies>
@@ -26,9 +26,19 @@
             <Path fileType="executable">/usr/bin/gh</Path>
             <Path fileType="doc">/usr/share/doc</Path>
         </Files>
+        <RuntimeDependencies>
+            <Dependency>xdg-utils</Dependency>
+        </RuntimeDependencies>
     </Package>
 
     <History>
+        <Update release="2">
+            <Date>2024-10-20</Date>
+            <Version>2.59.0</Version>
+            <Comment>Unorphanage and version bump</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="1">
             <Date>2020-02-24</Date>
             <Version>0.5.7</Version>


### PR DESCRIPTION
- Unorphane `github-cli`, I'll be maintaining this.
- Update `golang` and `github-cli` to latest stable versions respectively.
- Add a new package: `nvidia-prime`

-----

`nvidia-prime` is a package originating from Arch Linux that allows users to run apps exclusively on NVIDIA GPUs. This is really useful for systems without a MUX switch (I.e. laptops with "NVIDIA Optimus") as there's no other way to force utilize NVIDIA GPUs. This can be combined with `switcheroo-control` to allow DEs like GNOME to let users do it from graphical user interface as well.
