### PR TITLE
Initial package release for libva-nvidia-driver

### DIFF
--- a/x11/driver/libva-nvidia-driver/actions.py
+++ b/x11/driver/libva-nvidia-driver/actions.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Licensed under the GNU General Public License, version 3.
+# See the file http://www.gnu.org/copyleft/gpl.txt
+
+from pisi.actionsapi import shelltools
+from pisi.actionsapi import pisitools
+from pisi.actionsapi import mesontools
+
+def setup():
+    mesontools.configure()
+
+def build():
+    mesontools.build()
+
+def install():
+    shelltools.copy("COPYING", "LICENSE")
+    mesontools.install()
+    pisitools.dodoc("LICENSE", "README*")

--- a/x11/driver/libva-nvidia-driver/pspec.xml
+++ b/x11/driver/libva-nvidia-driver/pspec.xml
@@ -1,0 +1,44 @@
+<PISI>
+    <Source>
+        <Name>libva-nvidia-driver</Name>
+        <Homepage>https://github.com/elFarto/nvidia-vaapi-driver/</Homepage>
+        <Packager>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Packager>
+        <License>MIT</License>
+        <Summary>VA-API implementation that uses NVDEC as a backend</Summary>
+        <Description>libva-nvidia-driver is a VA-API implementation that uses NVDEC as a backend. This implementation is noted to be "specifically designed to be used by Firefox for accelerated decode of web content, and may not operate correctly in other applications" by the upstream developer.</Description>
+        <BuildDependencies>
+            <Dependency>ffnvcodec</Dependency>
+            <Dependency>libva</Dependency>
+            <Dependency>meson</Dependency>
+            <Dependency>libdrm-devel</Dependency>
+            <Dependency>libva-devel</Dependency>
+        </BuildDependencies>
+        <Archive sha1sum="02b4458ae84a3ad86786a7f8af42c90f1b337d88" type="targz">https://github.com/elFarto/nvidia-vaapi-driver/archive/v0.0.12.tar.gz</Archive>
+    </Source>
+    <Package>
+        <Name>libva-nvidia-driver</Name>
+        <RuntimeDependencies>
+            <Dependency>libglvnd</Dependency>
+            <Dependency>gst-plugins-bad</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="library">/usr/lib</Path>
+            <Path fileType="doc">/usr/share/doc</Path>
+        </Files>
+        <Conflicts>
+            <Package>vdpau-video</Package>
+        </Conflicts>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2024-10-20</Date>
+            <Version>0.0.12</Version>
+            <Comment>Initial Pisi Linux packaging</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
+    </History>
+</PISI>

--- a/x11/driver/libva-nvidia-driver/translations.xml
+++ b/x11/driver/libva-nvidia-driver/translations.xml
@@ -1,0 +1,7 @@
+<PISI>
+    <Source>
+        <Name>libva-nvidia-driver</Name>
+        <Summary xml:lang="tr">Arka uç (Backend) olarak NVDEC kullanan VA-API implamantasyonu.</Summary>
+        <Description xml:lang="tr">libva-nvidia-driver, arka uç (backend) olarak NVDEC kullanan bir VA-API implamantasyonudur. Bu implamantasyon upstream geliştiriciye göre "web içeriğinin hızlandırılmış çözümlemesi için Firefox tarafından kullanılması adına özellikle tasarlanmıştır, ve diğer uygulamalarda doğru çalışmayabilir."</Description>
+    </Source>
+</PISI>


### PR DESCRIPTION
Required with the proprietary drivers if KDE is in use and Spectacle is desired to be used.

Do NOT make this a hard dependency for Spectacle since it conflicts with the default vdpau-video.
