### PR TITLE
fixup! Initial package release for libva-nvidia-driver

### DIFF
--- a/x11/driver/libva-nvidia-driver/pspec.xml
+++ b/x11/driver/libva-nvidia-driver/pspec.xml
@@ -12,8 +12,8 @@
         <Summary>VA-API implementation that uses NVDEC as a backend</Summary>
         <Description>libva-nvidia-driver is a VA-API implementation that uses NVDEC as a backend. This implementation is noted to be "specifically designed to be used by Firefox for accelerated decode of web content, and may not operate correctly in other applications" by the upstream developer.</Description>
         <BuildDependencies>
+            <Dependency>libglvnd</Dependency>
             <Dependency>ffnvcodec</Dependency>
-<!--             <Dependency>libva</Dependency> -->
             <Dependency>meson</Dependency>
             <Dependency>libdrm-devel</Dependency>
             <Dependency>libva-devel</Dependency>
@@ -24,6 +24,7 @@
     <Package>
         <Name>libva-nvidia-driver</Name>
         <RuntimeDependencies>
+            <!-- Her iki yer için de gerekli. İlkinde derlemek için kontrol var (ki açıkça "runtime dependency" diyor), ikincisi de direkt çalışması için. -->
             <Dependency>libglvnd</Dependency>
             <Dependency>gst-plugins-bad</Dependency>
         </RuntimeDependencies>


### PR DESCRIPTION
Some dependency fixups, removing non-devel version of libva and
adding libglvnd as a build dependency too.

libglvnd has to exist in both types of dependencies as the source
explicitly checks for its presence in build time as "runtime dependency".
