### PR TITLE
Changes for captive portal detection

### DIFF
--- a/desktop/toolkit/granite7/actions.py
+++ b/desktop/toolkit/granite7/actions.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Licensed under the GNU General Public License, version 2
+# See the file http://www.gnu.org/copyleft/gpl.txt
+
+from pisi.actionsapi import pisitools
+from pisi.actionsapi import mesontools
+
+def setup():
+    mesontools.configure()
+
+def build():
+    mesontools.build()
+
+def install():
+    mesontools.install()
+
+    pisitools.dodoc("COPYING", "README.md")

--- a/desktop/toolkit/granite7/pspec.xml
+++ b/desktop/toolkit/granite7/pspec.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "https://pisilinux.org/projeler/pisi/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>granite7</Name>
+        <Homepage>https://github.com/elementary/granite</Homepage>
+        <Packager>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Packager>
+        <License>LGPLv3</License>
+        <PartOf>desktop</PartOf>
+        <Summary>Granite is a companion library for GTK and GLib.</Summary>
+        <Description>Granite is a companion library for GTK and GLib. Among other things, it provides complex widgets and convenience functions designed for use in apps built for elementary OS.</Description>
+        <Archive sha1sum="8421b31c48216c51c0292d7e116280e5cde5f7f0" type="targz">https://github.com/elementary/granite/archive/7.5.0.tar.gz</Archive>
+        <BuildDependencies>
+            <Dependency>gobject-introspection-devel</Dependency>
+            <Dependency>libgee-devel</Dependency>
+            <Dependency>gtk3-devel</Dependency>
+            <Dependency>vala-devel</Dependency>
+            <Dependency>meson</Dependency>
+            <Dependency>sassc</Dependency>
+        </BuildDependencies>
+    </Source>
+    
+    <Package>
+        <Name>granite7</Name>
+        <RuntimeDependencies>
+            <Dependency>gtk3</Dependency>
+            <Dependency>cairo</Dependency>
+            <Dependency>glib2</Dependency>
+            <Dependency>pango</Dependency>
+            <Dependency>libgee</Dependency>
+            <Dependency>gdk-pixbuf</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="executable">/usr/bin</Path>
+            <Path fileType="library">/usr/lib/girepository-1.0</Path>
+            <Path fileType="library">/usr/lib/libgranite*.so*</Path>
+            <Path fileType="data">/usr/share/applications</Path>
+            <Path fileType="doc">/usr/share/doc</Path>
+            <Path fileType="data">/usr/share/icons</Path>
+            <Path fileType="data">/usr/share/themes</Path>
+            <Path fileType="localedata">/usr/share/locale</Path>
+            <Path fileType="info">/usr/share/metainfo</Path>
+        </Files>
+    </Package>
+    
+    <Package>
+        <Name>granite7-devel</Name>
+        <Summary>Development files for granite</Summary>
+        <RuntimeDependencies>
+            <Dependency release="current">granite7</Dependency>
+            <Dependency>gtk3-devel</Dependency>
+            <Dependency>glib2-devel</Dependency>
+            <Dependency>libgee-devel</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="header">/usr/include</Path>
+            <Path fileType="library">/usr/lib/pkgconfig</Path>
+            <Path fileType="data">/usr/share/gir-1.0</Path>
+            <Path fileType="data">/usr/share/vala</Path>
+        </Files>
+    </Package>
+    
+    <History>
+        <Update release="1">
+            <Date>2024-10-22</Date>
+            <Version>7.5.0</Version>
+            <Comment>Initial packaging for Pisi Linux</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
+    </History>
+</PISI>

--- a/desktop/toolkit/granite7/translations.xml
+++ b/desktop/toolkit/granite7/translations.xml
@@ -1,0 +1,12 @@
+<PISI>
+    <Source>
+        <Name>granite7</Name>
+        <Summary>Granite, GTK ve GLib için bir eşlikçi kütüphanedir.</Summary>
+        <Description>Granite, GTK ve GLib için bir eşlikçi kütüphanedir. Diğer şeylerin aynında elementary OS için geliştirilmiş uygulamalarda kullanılması adına karışık araçlar ve kolaylık fonksiyonları sağlar.</Description>
+    </Source>
+
+    <Package>
+        <Name>granite7-devel</Name>
+        <Summary>granite7 için geliştirme dosyaları.</Summary>
+    </Package>
+</PISI>

--- a/network/connection/NetworkManager/files/20-connectivity.conf
+++ b/network/connection/NetworkManager/files/20-connectivity.conf
@@ -1,0 +1,2 @@
+[connectivity]
+uri=http://networkcheck.kde.org

--- a/network/connection/NetworkManager/pspec.xml
+++ b/network/connection/NetworkManager/pspec.xml
@@ -124,6 +124,7 @@
             <AdditionalFile owner="root" permission="0644" target="/usr/lib/tmpfiles.d/NetworkManager.conf">tmpfiles.conf</AdditionalFile>
             <AdditionalFile owner="root" permission="0644" target="/etc/NetworkManager/NetworkManager.conf">NetworkManager.conf</AdditionalFile>
             <AdditionalFile owner="root" permission="0644" target="/etc/NetworkManager/conf.d/dhcp.conf">dhcp.conf</AdditionalFile>
+            <AdditionalFile owner="root" permission="0644" target="/etc/NetworkManager/conf.d/20-connectivity.conf">20-connectivity.conf</AdditionalFile>
             <AdditionalFile owner="root" permission="0755" target="/usr/sbin/migrate-comar-network-profiles">migrate-comar-network-profiles</AdditionalFile>
             <AdditionalFile owner="root" permission="0644" target="/etc/polkit-1/localauthority/10-vendor.d/01-org.freedesktop.NetworkManager.settings.modify.system.pkla">gentoo/01-org.freedesktop.NetworkManager.settings.modify.system.pkla</AdditionalFile>
             <AdditionalFile owner="root" permission="0644" target="/usr/share/polkit-1/rules.d/10-vendor.d/01-org.freedesktop.ModemManager1.rules">01-org.freedesktop.ModemManager1.rules</AdditionalFile>
@@ -160,6 +161,12 @@
     </Package>
 
     <History>
+        <Update release="49">
+            <Date>2024-10-22</Date>
+            <Version>1.48.12</Version>
+            <Comment>Add configuration for captive portal detection.</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
         <Update release="48">
             <Date>2024-10-04</Date>
             <Version>1.48.12</Version>

--- a/network/connection/capnet-assist/actions.py
+++ b/network/connection/capnet-assist/actions.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Licensed under the GNU General Public License, version 3.
+# See the file http://www.gnu.org/licenses/gpl.txt
+
+from pisi.actionsapi import mesontools
+from pisi.actionsapi import pisitools
+from pisi.actionsapi import get
+
+def setup():
+    mesontools.configure("-Db_pie=false")
+
+def build():
+    mesontools.build()
+
+def install():
+    mesontools.install()
+
+    pisitools.dodoc("COPYING", "README*")

--- a/network/connection/capnet-assist/files/more-widely-known-portal.patch
+++ b/network/connection/capnet-assist/files/more-widely-known-portal.patch
@@ -1,0 +1,28 @@
+From 018bcb5824a956409baef6cf68a8469a6c0e8c1b Mon Sep 17 00:00:00 2001
+From: Bahar Kurt <kurtbahartr@users.noreply.github.com>
+Date: Tue, 22 Oct 2024 12:10:52 +0300
+Subject: [PATCH] Change captive portal detection URL to something known more
+ widely
+
+---
+ src/MainWindow.vala | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/MainWindow.vala b/src/MainWindow.vala
+index a125814..c410eeb 100644
+--- a/src/MainWindow.vala
++++ b/src/MainWindow.vala
+@@ -19,7 +19,9 @@
+ */
+ 
+ public class Captive.MainWindow : Gtk.ApplicationWindow {
+-    private const string DUMMY_URL = "http://capnet.elementary.io";
++    // This was elementaryOS' own capnet server, which isn't acknowledged by networks like universities.
++    // As a quick workaround, we can use a more widely acknowledged server, like Google's.
++    private const string DUMMY_URL = "http://gstatic.com/generate_204";
+ 
+     private Adw.TabView tabview;
+     private Granite.HeaderLabel cert_subject;
+-- 
+2.46.2
+

--- a/network/connection/capnet-assist/pspec.xml
+++ b/network/connection/capnet-assist/pspec.xml
@@ -25,6 +25,9 @@
             <Dependency>vala-devel</Dependency>
             <Dependency>webkit2gtk-6.0-devel</Dependency>
         </BuildDependencies>
+        <Patches>
+            <Patch>more-widely-known-portal.patch</Patch>
+        </Patches>
     </Source>
 
     <Package>

--- a/network/connection/capnet-assist/pspec.xml
+++ b/network/connection/capnet-assist/pspec.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "https://www.pisilinux.org/projeler/pisi/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>capnet-assist</Name>
+        <Homepage>https://github.com/elementary/capnet-assist</Homepage>
+        <Packager>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Packager>
+        <License>GPLv3</License>
+        <Summary>Captive Network Assistant</Summary>
+        <Description>Log into captive portals—like Wi-Fi networks at coffee shops, airports, and trains—with ease. Captive Network Assistant automatically opens to help you get connected.</Description>
+        <Archive sha1sum="159afd53446ff21ef20920d39311c8b5b2136d22" type="targz">https://github.com/elementary/capnet-assist/archive/8.0.0.tar.gz</Archive>
+        <BuildDependencies>
+            <Dependency>gcr-4-devel</Dependency>
+            <Dependency>git</Dependency>
+            <Dependency>glib2-devel</Dependency>
+            <Dependency>gtk4-devel</Dependency>
+            <Dependency>granite7-devel</Dependency>
+            <Dependency>intltool</Dependency>
+            <Dependency>libadwaita-devel</Dependency>
+            <Dependency>granite-devel</Dependency>
+            <Dependency>meson</Dependency>
+            <Dependency>vala-devel</Dependency>
+            <Dependency>webkit2gtk-6.0-devel</Dependency>
+        </BuildDependencies>
+    </Source>
+
+    <Package>
+        <Name>capnet-assist</Name>
+        <RuntimeDependencies>
+            <Dependency>gcr-4</Dependency>
+            <Dependency>glib2</Dependency>
+            <Dependency>gtk4</Dependency>
+            <Dependency>libadwaita</Dependency>
+            <Dependency>granite7</Dependency>
+            <Dependency>libsoup</Dependency>
+            <Dependency>NetworkManager</Dependency>
+            <Dependency>webkit2gtk-6.0</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="executable">/usr/bin</Path>
+            <Path fileType="man">/usr/share/man</Path>
+            <Path fileType="doc">/usr/share/doc</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas</Path>
+            <Path fileType="data">/usr/share/icons</Path>
+            <Path fileType="info">/usr/share/metainfo</Path>
+            <Path fileType="data">/usr/share/locale</Path>
+            <Path fileType="data">/usr/share/applications</Path>
+        </Files>
+    </Package>
+
+    <History>
+        <Update release="1">
+            <Date>2024-10-22</Date>
+            <Version>8.0.0</Version>
+            <Comment>Initial packaging for Pisi Linux</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
+    </History>
+</PISI>

--- a/network/connection/capnet-assist/translations.xml
+++ b/network/connection/capnet-assist/translations.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<PISI>
+    <Source>
+        <Name>capnet-assist</Name>
+        <Summary xml:lang="tr">Captive Ağ Asistanı</Summary>
+        <Description xml:lang="tr">Kahve dükkanları, havalimanları ve trenlerdeki Wi-Fi ağları gibi captive portal'lara kolaylıkla giriş yapın. Captive Ağ Asistanı bağlanmanıza yardımcı olmak için otomatik olarak açılır.</Description>
+    </Source>
+</PISI>

--- a/network/misc/webkit2gtk-4.1/pspec.xml
+++ b/network/misc/webkit2gtk-4.1/pspec.xml
@@ -72,6 +72,7 @@
         <Name>webkit2gtk-4.1</Name>
         <RuntimeDependencies>
             <Dependency>atk</Dependency>
+            <Dependency>bubblewrap</Dependency>
             <Dependency>zlib</Dependency>
             <Dependency>gtk3</Dependency>
 <!--             <Dependency>gtk4</Dependency> -->
@@ -125,6 +126,7 @@
             <Dependency>gst-plugins-base</Dependency>
             <Dependency>gst-plugins-good</Dependency>
             <Dependency>gobject-introspection</Dependency>
+            <Dependency>xdg-dbus-proxy</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib</Path>
@@ -155,6 +157,13 @@
     </Package>
 
     <History>
+        <Update release="4">
+            <Date>2024-10-22</Date>
+            <Version>2.42.1</Version>
+            <Comment>Add missing dependencies.</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="3">
             <Date>2023-10-24</Date>
             <Version>2.42.1</Version>

--- a/network/misc/webkit2gtk-5.0/pspec.xml
+++ b/network/misc/webkit2gtk-5.0/pspec.xml
@@ -68,6 +68,7 @@
         <Name>webkit2gtk-5.0</Name>
         <RuntimeDependencies>
             <Dependency>atk</Dependency>
+            <Dependency>bubblewrap</Dependency>
             <Dependency>zlib</Dependency>
             <Dependency>gtk3</Dependency>
             <Dependency>gtk4</Dependency>
@@ -117,6 +118,7 @@
             <Dependency>gst-plugins-base</Dependency>
             <Dependency>gst-plugins-good</Dependency>
             <Dependency>gobject-introspection</Dependency>
+            <Dependency>xdg-dbus-proxy</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib</Path>
@@ -147,6 +149,13 @@
     </Package>
 
     <History>
+        <Update release="3">
+            <Date>2024-10-22</Date>
+            <Version>2.38.0</Version>
+            <Comment>Add missing dependencies.</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="2">
             <Date>2022-10-24</Date>
             <Version>2.38.0</Version>

--- a/network/misc/webkit2gtk-6.0/pspec.xml
+++ b/network/misc/webkit2gtk-6.0/pspec.xml
@@ -71,6 +71,7 @@
         <Name>webkit2gtk-6.0</Name>
         <RuntimeDependencies>
             <Dependency>atk</Dependency>
+            <Dependency>bubblewrap</Dependency>
             <Dependency>zlib</Dependency>
             <Dependency>gtk3</Dependency>
             <Dependency>gtk4</Dependency>
@@ -124,6 +125,7 @@
             <Dependency>gst-plugins-base</Dependency>
             <Dependency>gst-plugins-good</Dependency>
             <Dependency>gobject-introspection</Dependency>
+            <Dependency>xdg-dbus-proxy</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib</Path>
@@ -154,6 +156,13 @@
     </Package>
 
     <History>
+        <Update release="5">
+            <Date>2024-10-22</Date>
+            <Version>2.44.0</Version>
+            <Comment>Add missing dependencies.</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="4">
             <Date>2024-04-03</Date>
             <Version>2.44.0</Version>

--- a/network/misc/webkit2gtk/pspec.xml
+++ b/network/misc/webkit2gtk/pspec.xml
@@ -70,6 +70,7 @@
         <Name>webkit2gtk</Name>
         <RuntimeDependencies>
             <Dependency>atk</Dependency>
+            <Dependency>bubblewrap</Dependency>
             <Dependency>zlib</Dependency>
             <Dependency>gtk3</Dependency>
             <Dependency>mesa</Dependency>
@@ -120,6 +121,7 @@
             <Dependency>gst-plugins-base</Dependency>
             <Dependency>gst-plugins-good</Dependency>
             <Dependency>gobject-introspection</Dependency>
+            <Dependency>xdg-dbus-proxy</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib</Path>
@@ -150,6 +152,13 @@
     </Package>
 
     <History>
+        <Update release="9">
+            <Date>2024-10-22</Date>
+            <Version>2.42.1</Version>
+            <Comment>Add missing dependencies.</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="8">
             <Date>2023-10-24</Date>
             <Version>2.42.1</Version>


### PR DESCRIPTION
New packages;
- graphite7 - Dependency for capnet-assist
- capnet-assist - elementaryOS captive portal detection

Changes to existing packages;
- NetworkManager: Add configuration for captive portal detection
  - This change won't launch capnet-assist on its own but instead change connectivity state to PORTAL so DEs can handle this themselves.
- webkit2gtk*: Add bubblewrap and xdg-dbus-proxy as runtime dependencies too.
  - This was supposed to be done right in the beginning but I guess it didn't break anything until capnet-assist was added.
