### PR TITLE
Add `kdeplasma-desktop-kf6` as a dependency to `plasma-desktop`

### DIFF
--- a/desktop/kde6/plasma/plasma-desktop-kf6/pspec.xml
+++ b/desktop/kde6/plasma/plasma-desktop-kf6/pspec.xml
@@ -141,6 +141,7 @@
             <Dependency>kjobwidgets-kf6</Dependency>
             <Dependency>qt6-wayland</Dependency>
             <Dependency>kdeclarative-kf6</Dependency>
+            <Dependency>kdeplasma-addons-kf6</Dependency>
             <Dependency>kglobalaccel-kf6</Dependency>
             <Dependency>libksysguard-kf6</Dependency>
             <Dependency>libxkbcommon</Dependency>
@@ -180,6 +181,13 @@
     </Package>
 
     <History>
+        <Update release="15">
+            <Date>2024-10-22</Date>
+            <Version>6.2.0</Version>
+            <Comment>Add kdeplasma-addons as a dependency.</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="14">
             <Date>2024-10-08</Date>
             <Version>6.2.0</Version>


### PR DESCRIPTION
This package provides useful things like caps lock indicator, which is something I, among with many other KDE users, rely on on laptops in daily use cases.