### PR TITLE
Enable experimental R/W support by default downstream on APFS DRV

### DIFF
--- a/kernel/drivers/module-linux-apfs-rw/files/rw-by-default.patch
+++ b/kernel/drivers/module-linux-apfs-rw/files/rw-by-default.patch
@@ -1,0 +1,55 @@
+From e9dfb693ab15084c38805631a90730bc8c22dd37 Mon Sep 17 00:00:00 2001
+From: Bahar Kurt <kurtbahartr@users.noreply.github.com>
+Date: Tue, 22 Oct 2024 10:07:18 +0300
+Subject: [PATCH] Enable the experimental write support by default
+
+It looks safe enough for daily usage.
+---
+ super.c | 14 ++++++++++----
+ 1 file changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/super.c b/super.c
+index 5fc2b2b..a07be9a 100644
+--- a/super.c
++++ b/super.c
+@@ -1184,6 +1184,9 @@ static int parse_options(struct super_block *sb, char *options)
+ 	/* Set default values before parsing */
+ 	nx_flags = 0;
+ 
++	/* DOWNSTREAM: Set r/w to be the default. It looks safe and sane enough to me. - Bedirhan */
++	nx_flags |= APFS_READWRITE;
++
+ 	if (!options)
+ 		goto out;
+ 
+@@ -1196,10 +1199,13 @@ static int parse_options(struct super_block *sb, char *options)
+ 		switch (token) {
+ 		case Opt_readwrite:
+ 			/*
+-			 * Write support is not safe yet, so keep it disabled
+-			 * unless the user requests it explicitly.
++			 * Write support is not safe yet, and it was disabled upstream,
++			 * but it looks safe and usable enough for data recovery and
++			 * little operations like fixing corrupted files.
+ 			 */
+-			nx_flags |= APFS_READWRITE;
++			//nx_flags |= APFS_READWRITE;
++			apfs_warn(sb, "no need to explicitly state r/w mounts");
++			apfs_notice(sb, "we have already made it the default for you downstream");
+ 			break;
+ 		case Opt_cknodes:
+ 			/*
+@@ -1242,9 +1248,9 @@ out:
+ 	if (!(sb->s_flags & SB_RDONLY)) {
+ 		if (nxi->nx_flags & APFS_READWRITE) {
+ 			apfs_notice(sb, "experimental write support is enabled");
++			apfs_notice(sb, "this is default only downstream, and you should blame the packager for loss of written data, not the upstream");
+ 		} else {
+ 			apfs_warn(sb, "experimental writes disabled to avoid data loss");
+-			apfs_warn(sb, "if you really want them, check the README");
+ 			sb->s_flags |= SB_RDONLY;
+ 		}
+ 	}
+-- 
+2.46.2
+

--- a/kernel/drivers/module-linux-apfs-rw/pspec.xml
+++ b/kernel/drivers/module-linux-apfs-rw/pspec.xml
@@ -16,6 +16,9 @@
         <BuildDependencies>
            <Dependency version="6.6.56">kernel-module-headers</Dependency>
         </BuildDependencies>
+        <Patches>
+            <Patch>rw-by-default.patch</Patch>
+        </Patches>
     </Source>
 
     <Package>
@@ -33,6 +36,13 @@
     </Package>
 
     <History>
+        <Update release="3">
+            <Date>2024-10-23</Date>
+            <Version>0.3.11</Version>
+            <Comment>Enable experimental R/W by default.</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="2">
             <Date>2024-10-14</Date>
             <Version>0.3.11</Version>


### PR DESCRIPTION
As per the requests, and with the help from upstream. I had some tests
done for this and it seemed stable enough to me. The upstream did
mention some niche cases where the mounted APFS drive would be
corrupted, but I doubt it will ever hit an average user especially with
the default configuration.
