### PR TITLE
Bump the packages I maintain that are out of date

### DIFF
--- a/desktop/toolkit/granite7/pspec.xml
+++ b/desktop/toolkit/granite7/pspec.xml
@@ -12,7 +12,7 @@
         <PartOf>desktop</PartOf>
         <Summary>Granite is a companion library for GTK and GLib.</Summary>
         <Description>Granite is a companion library for GTK and GLib. Among other things, it provides complex widgets and convenience functions designed for use in apps built for elementary OS.</Description>
-        <Archive sha1sum="8421b31c48216c51c0292d7e116280e5cde5f7f0" type="targz">https://github.com/elementary/granite/archive/7.5.0.tar.gz</Archive>
+        <Archive sha1sum="634124eb9ecc0d0d8b40e244e26c86ea0896a325" type="targz">https://github.com/elementary/granite/archive/7.6.0.tar.gz</Archive>
         <BuildDependencies>
             <Dependency>gobject-introspection-devel</Dependency>
             <Dependency>libgee-devel</Dependency>
@@ -64,6 +64,13 @@
     </Package>
     
     <History>
+        <Update release="2">
+            <Date>2024-12-30</Date>
+            <Version>7.6.0</Version>
+            <Comment>Version bump</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="1">
             <Date>2024-10-22</Date>
             <Version>7.5.0</Version>

--- a/kernel/drivers/module-linux-apfs-rw/pspec.xml
+++ b/kernel/drivers/module-linux-apfs-rw/pspec.xml
@@ -12,7 +12,7 @@
         <IsA>driver</IsA>
         <Summary>Experimental support for APFS</Summary>
         <Description>The Apple File System (APFS) is the copy-on-write filesystem currently used on all Apple devices. This module provides a degree of experimental support on Linux.</Description>
-        <Archive sha1sum="df749e1810304783174bbccb5b0cb4f991c8299a" type="targz">https://github.com/linux-apfs/linux-apfs-rw/archive/refs/tags/v0.3.11.tar.gz</Archive>
+        <Archive sha1sum="129a58755480d7c7e8c2edf7af7a2bc12f3cff9c" type="targz">https://github.com/linux-apfs/linux-apfs-rw/archive/refs/tags/v0.3.12.tar.gz</Archive>
         <BuildDependencies>
            <Dependency version="6.6.67">kernel-module-headers</Dependency>
         </BuildDependencies>
@@ -36,6 +36,13 @@
     </Package>
 
     <History>
+        <Update release="6">
+            <Date>2024-12-30</Date>
+            <Version>0.3.12</Version>
+            <Comment>Version bump</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="5">
             <Date>2024-12-20</Date>
             <Version>0.3.11</Version>

--- a/kernel/tools/apfsprogs/pspec.xml
+++ b/kernel/tools/apfsprogs/pspec.xml
@@ -12,7 +12,7 @@
         <IsA>driver</IsA>
         <Summary>Experimental APFS tools for Linux</Summary>
         <Description>Apfsprogs is a suite of userspace utilities for working with the Apple File System on Linux. It's intended mainly to help test the Linux kernel module, located at https://github.com/linux-apfs/linux-apfs-rw.git</Description>
-        <Archive sha1sum="8e2d510109ac0a733f9e6c8941c467ffbd8cf3b3" type="targz">https://github.com/linux-apfs/apfsprogs/archive/f31d7c2.tar.gz</Archive>
+        <Archive sha1sum="ebc5bd70ab686cbec7f49d0202d49bddd3784464" type="targz">https://github.com/linux-apfs/apfsprogs/archive/v0.2.0.tar.gz</Archive>
     </Source>
 
     <Package>
@@ -25,12 +25,16 @@
             <Path fileType="man">/usr/share/man/man8</Path>
             <Path fileType="doc">/usr/share/doc</Path>
         </Files>
-        <BuildFlags>
-            <Flag>noDelta</Flag>
-        </BuildFlags>
     </Package>
 
     <History>
+        <Update release="2">
+            <Date>2024-12-30</Date>
+            <Version>0.2.0</Version>
+            <Comment>Initial "stable" build based on GitHub release</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="1">
             <Date>2024-10-03</Date>
             <Version>0.1</Version>

--- a/network/connection/capnet-assist/pspec.xml
+++ b/network/connection/capnet-assist/pspec.xml
@@ -11,7 +11,7 @@
         <License>GPLv3</License>
         <Summary>Captive Network Assistant</Summary>
         <Description>Log into captive portals—like Wi-Fi networks at coffee shops, airports, and trains—with ease. Captive Network Assistant automatically opens to help you get connected.</Description>
-        <Archive sha1sum="159afd53446ff21ef20920d39311c8b5b2136d22" type="targz">https://github.com/elementary/capnet-assist/archive/8.0.0.tar.gz</Archive>
+        <Archive sha1sum="0b707cf617a8d948ab9b8ba1d602647dd3a00c48" type="targz">https://github.com/elementary/capnet-assist/archive/8.0.1.tar.gz</Archive>
         <BuildDependencies>
             <Dependency>gcr-4-devel</Dependency>
             <Dependency>git</Dependency>
@@ -55,6 +55,13 @@
     </Package>
 
     <History>
+        <Update release="2">
+            <Date>2024-12-30</Date>
+            <Version>8.0.1</Version>
+            <Comment>Version bump</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="1">
             <Date>2024-10-22</Date>
             <Version>8.0.0</Version>

--- a/programming/scm/github-cli/pspec.xml
+++ b/programming/scm/github-cli/pspec.xml
@@ -13,7 +13,7 @@
         <IsA>app:console</IsA>
         <Summary>GitHub CLI</Summary>
         <Description>"gh" is GitHub on the command line. It brings pull requests, issues, and other GitHub concepts to the terminal next to where you are already working with "git" and your code.</Description>
-        <Archive sha1sum="d0643e0651d0482ad6c78d7cb36743228af27d98" type="targz">https://github.com/cli/cli/archive/v2.59.0.tar.gz</Archive>
+        <Archive sha1sum="1529555ea61828a5c9fb51467982de842f08040b" type="targz">https://github.com/cli/cli/archive/v2.64.0.tar.gz</Archive>
         <BuildDependencies>
             <Dependency>golang</Dependency>
         </BuildDependencies>
@@ -32,6 +32,13 @@
     </Package>
 
     <History>
+        <Update release="3">
+            <Date>2024-12-30</Date>
+            <Version>2.64.0</Version>
+            <Comment>Version bump</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="2">
             <Date>2024-10-20</Date>
             <Version>2.59.0</Version>

--- a/x11/driver/libva-nvidia-driver/pspec.xml
+++ b/x11/driver/libva-nvidia-driver/pspec.xml
@@ -18,7 +18,7 @@
             <Dependency>libdrm-devel</Dependency>
             <Dependency>libglvnd-devel</Dependency>
         </BuildDependencies>
-        <Archive sha1sum="02b4458ae84a3ad86786a7f8af42c90f1b337d88" type="targz">https://github.com/elFarto/nvidia-vaapi-driver/archive/v0.0.12.tar.gz</Archive>
+        <Archive sha1sum="ed008b026594154041476339874f1baa38c6d43c" type="targz">https://github.com/elFarto/nvidia-vaapi-driver/archive/v0.0.13.tar.gz</Archive>
     </Source>
 
     <Package>
@@ -38,6 +38,13 @@
     </Package>
 
     <History>
+        <Update release="2">
+            <Date>2024-12-30</Date>
+            <Version>0.0.13</Version>
+            <Comment>Version bump</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="1">
             <Date>2024-10-20</Date>
             <Version>0.0.12</Version>


### PR DESCRIPTION
The stats were grabbed from [my repology profile](https://repology.org/maintainer/bedirhan.kurt@outlook.com).

- **Bump apfsprogs**
- **Bump capnet-assist**
- **Bump github-cli**
- **Bump granite7**
- **Bump libva-nvidia-driver**
- **Bump module-linux-apfs-rw**
