### PR TITLE
Introduce gdm-settings and its missing dep blueprint-compiler

### DIFF
--- a/desktop/gnome/lookandfeel/gdm-settings/actions.py
+++ b/desktop/gnome/lookandfeel/gdm-settings/actions.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Licensed under GNU General Public License, version 3.
+# See the file https://www.gnu.org/licenses/gpl.txt
+
+from pisi.actionsapi import mesontools
+from pisi.actionsapi import get
+
+def setup():
+    mesontools.configure()
+
+def build():
+    mesontools.build()
+
+def install():
+    mesontools.install()

--- a/desktop/gnome/lookandfeel/gdm-settings/pspec.xml
+++ b/desktop/gnome/lookandfeel/gdm-settings/pspec.xml
@@ -1,0 +1,50 @@
+<PISI>
+    <Source>
+        <Name>gdm-settings</Name>
+        <Homepage>https://gdm-settings.github.io/</Homepage>
+        <Packager>
+            <Name>Bahar Kurt</Name>
+            <Email>kurtbahartr@gmail.com</Email>
+        </Packager>
+        <License>MIT</License>
+        <PartOf>util.misc</PartOf>
+        <Summary>Customize your login screen</Summary>
+        <Description>A settings app for Gnome's Login Manager, GDM</Description>
+        <BuildDependencies>
+            <Dependency>meson</Dependency>
+            <Dependency>blueprint-compiler</Dependency>
+            <Dependency>gobject-introspection-devel</Dependency>
+            <Dependency>libadwaita-devel</Dependency>
+            <Dependency>python3-pygobject3-devel</Dependency>
+            <Dependency>gtk4-devel</Dependency>
+        </BuildDependencies>
+        <Archive sha1sum="464c5b90d9db4030e2b2c1ddd3a364d7f604167b" type="targz">https://github.com/gdm-settings/gdm-settings/archive/refs/tags/v5.0.tar.gz</Archive>
+    </Source>
+    <Package>
+        <Name>gdm-settings</Name>
+        <Summary>Customize your login screen</Summary>
+        <RuntimeDependencies>
+            <Dependency>gdm</Dependency>
+            <Dependency>libadwaita</Dependency>
+            <Dependency>glib2-devel</Dependency>
+            <Dependency>gtk4</Dependency>
+            <Dependency>python3-pygobject3</Dependency>
+            <Dependency>gettext</Dependency>
+            <Dependency>polkit</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="executable">/usr/bin</Path>
+            <Path fileType="doc">/usr/share</Path>
+            <Path fileType="library">/usr/lib</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2024-12-31</Date>
+            <Version>5.0</Version>
+            <Comment>Initial packaging for PiSi.</Comment>
+            <Name>Bahar Kurt</Name>
+            <Email>kurtbahartr@gmail.com</Email>
+        </Update>
+    </History>
+</PISI>

--- a/desktop/gnome/lookandfeel/gdm-settings/translations.xml
+++ b/desktop/gnome/lookandfeel/gdm-settings/translations.xml
@@ -1,0 +1,11 @@
+<PISI>
+    <Source>
+        <Name>gdm-settings</Name>
+        <Summary xml:lang="tr">Giriş ekranınızı özelleştirin</Summary>
+        <Description xml:lang="tr">Gnome'un giriş ekranı, GDM, için bir ayar uygulaması</Description>
+    </Source>
+    <Package>
+        <Name>gdm-settings</Name>
+        <Summary xml:lang="tr">Giriş ekranınızı özelleştirin</Summary>
+    </Package>
+</PISI>

--- a/programming/build/blueprint-compiler/actions.py
+++ b/programming/build/blueprint-compiler/actions.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Licensed under GNU General Public License, version 3.
+# See the file https://www.gnu.org/licenses/gpl.txt
+
+from pisi.actionsapi import mesontools
+from pisi.actionsapi import get
+
+def setup():
+    mesontools.configure()
+
+def build():
+    mesontools.build()
+
+def install():
+    mesontools.install()

--- a/programming/build/blueprint-compiler/pspec.xml
+++ b/programming/build/blueprint-compiler/pspec.xml
@@ -1,0 +1,42 @@
+<PISI>
+    <Source>
+        <Name>blueprint-compiler</Name>
+        <Homepage>https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/</Homepage>
+        <Packager>
+            <Name>Bahar Kurt</Name>
+            <Email>kurtbahartr@gmail.com</Email>
+        </Packager>
+        <License>LGPL-3.0+</License>
+        <PartOf>programming.languages</PartOf>
+        <Summary>Blueprint is a markup language and compiler for GTK 4 user interfaces.</Summary>
+        <Description>Blueprint is still experimental. Future versions may have breaking changes, and most GTK tutorials use XML syntax.</Description>
+        <BuildDependencies>
+            <Dependency>git</Dependency>
+            <Dependency>meson</Dependency>
+        </BuildDependencies>
+        <Archive sha1sum="529ff901ad94e351047fc474f29d7002274ea88e" type="targz">https://gitlab.gnome.org/jwestman/blueprint-compiler/-/archive/v0.14.0/blueprint-compiler-v0.14.0.tar.gz</Archive>
+    </Source>
+    <Package>
+        <Name>blueprint-compiler</Name>
+        <Summary>Blueprint is a markup language and compiler for GTK 4 user interfaces.</Summary>
+        <RuntimeDependencies>
+            <Dependency>gobject-introspection</Dependency>
+            <Dependency>python3</Dependency>
+            <Dependency>python3-pygobject3</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="executable">/usr/bin</Path>
+            <Path fileType="doc">/usr/share</Path>
+            <Path fileType="library">/usr/lib</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2024-12-31</Date>
+            <Version>0.14.0</Version>
+            <Comment>Initial packaging for PiSi.</Comment>
+            <Name>Bahar Kurt</Name>
+            <Email>kurtbahartr@gmail.com</Email>
+        </Update>
+    </History>
+</PISI>

--- a/programming/build/blueprint-compiler/translations.xml
+++ b/programming/build/blueprint-compiler/translations.xml
@@ -1,0 +1,11 @@
+<PISI>
+  <Source>
+    <Name>blueprint-compiler</Name>
+    <Summary xml:lang="tr">Blueprint GTK 4 kullanıcı arayüzleri için bir bir markup ve dili ve derleyicidir.</Summary>
+    <Description xml:lang="tr">Blueprint hâlâ deneyseldir. Gelecek sürümlerin kırıcı değişiklikleri olabilir, ve çoğu GTK eğiticileri XML notasyonunu kullanmaktadır.</Description>
+  </Source>
+  <Package>
+    <Name>blueprint-compiler</Name>
+    <Summary xml:lang="tr">Blueprint GTK 4 kullanıcı arayüzleri için bir bir markup ve dili ve derleyicidir.</Summary>
+  </Package>
+</PISI>


### PR DESCRIPTION
gdm-settings is pretty useful for customizing GNOME's login screen without having to dig through configuration files and all those hacks manually.