### PR TITLE
Update pspec.xml

### DIFF
--- a/multimedia/sound/celt/pspec.xml
+++ b/multimedia/sound/celt/pspec.xml
@@ -3,7 +3,7 @@
 <PISI>
     <Source>
         <Name>celt</Name>
-        <Homepage>http://www.celt-codec.org/</Homepage>
+        <Homepage>https://www.celt-codec.org/</Homepage>
         <Packager>
             <Name>PisiLinux Community</Name>
             <Email>admins@pisilinux.org</Email>
@@ -11,7 +11,7 @@
         <License>BSD</License>
         <Summary>An audio codec for use in low-delay speech and audio communication</Summary>
         <Description>CELT (Constrained Energy Lapped Transform) is an ultra-low delay audio codec designed for realtime transmission of high quality speech and audio. This is meant to close the gap between traditional speech codecs (such as Speex) and traditional audio codecs (such as Vorbis).</Description>
-        <Archive sha1sum="7730b96a6615183505e5ff23cd9b4fea83540e15" type="targz">http://downloads.us.xiph.org/releases/celt/celt-0.11.3.tar.gz</Archive>
+        <Archive sha1sum="7730b96a6615183505e5ff23cd9b4fea83540e15" type="targz">https://ftp.osuosl.org/pub/xiph/releases/celt/celt-0.11.3.tar.gz</Archive>
         <BuildDependencies>
             <Dependency>libogg-devel</Dependency>
         </BuildDependencies>
@@ -45,6 +45,12 @@
     </Package>
 
     <History>
+	    <Update release="6">
+            <Date>2025-05-01</Date>
+            <Version>0.11.3</Version>
+            <Comment>Rebuild</Comment>
+            <Name>Pisi Linux Community</Name>
+            <Email>admin@pisilinux.org</Email>
 		<Update release="5">
             <Date>2020-01-12</Date>
             <Version>0.11.3</Version>


### PR DESCRIPTION
CELT codec'i IETF Opus codec'ine entegre edilmiştir ve artık geçersizdir.  https://www.celt-codec.org/news/ (eski)
https://opus-codec.org (yeni)