### PR TITLE
nvidia: Add libva-nvidia-driver as a dependency

### DIFF
--- a/kernel/drivers/module-nvidia-current/pspec.xml
+++ b/kernel/drivers/module-nvidia-current/pspec.xml
@@ -30,6 +30,7 @@
         <Summary>Kernel module for current NVIDIA graphics driver releases</Summary>
         <RuntimeDependencies>
             <Dependency version="6.6.87">kernel</Dependency>
+            <Dependency>libva-nvidia-driver</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library" permanent="true">/lib/modules</Path>
@@ -165,6 +166,7 @@
         <Summary>NVIDIA driver sources for linux</Summary>
         <RuntimeDependencies>
             <Dependency>dkms</Dependency>
+            <Dependency>libva-nvidia-driver</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="config">/etc/modprobe.d/nvidia-current-dkms.conf</Path>
@@ -231,6 +233,13 @@
     </Package>
     
     <History>
+        <Update release="84">
+            <Date>2025-05-09</Date>
+            <Version>565.57.01</Version>
+            <Comment>Add libva-nvidia-driver as a dependency</Comment>
+            <Name>Pisi Linux Community</Name>
+            <Email>admin@pisilinux.org</Email>
+        </Update>
         <Update release="83">
             <Date>2025-04-17</Date>
             <Version>565.57.01</Version>


### PR DESCRIPTION
Fixes apps like Spectacle.