### PR TITLE
Initial packaging for gnome-browser-connector

### DIFF
--- a/desktop/gnome/util/gnome-browser-connector/actions.py
+++ b/desktop/gnome/util/gnome-browser-connector/actions.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Licensed under the GNU General Public License, version 3.
+# See the file http://www.gnu.org/copyleft/gpl.txt
+
+from pisi.actionsapi import autotools
+from pisi.actionsapi import pisitools
+from pisi.actionsapi import shelltools
+from pisi.actionsapi import mesontools
+from pisi.actionsapi import get
+
+def setup():
+    mesontools.configure()
+
+def build():
+    mesontools.build()
+
+def install():
+    mesontools.install()
+
+    # Fixup for Python version
+    # Pisi Linux links main Python executable to Python2, which causes
+    # issues with the connector and its host process
+    shelltools.system("""sed -i -e '/#!/s/python/python3/' %s/usr/bin/gnome-browser-connector*""" % get.installDIR())
+
+    pisitools.dodoc("NEWS", "LICENSE*")

--- a/desktop/gnome/util/gnome-browser-connector/pspec.xml
+++ b/desktop/gnome/util/gnome-browser-connector/pspec.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "https://pisilinux.org/projeler/pisi/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>gnome-browser-connector</Name>
+        <Homepage>https://gitlab.gnome.org/GNOME/gnome-browser-connector</Homepage>
+        <Packager>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Packager>
+        <License>GPLv3</License>
+        <Summary xml:lang="en">Native browser connector for integration with extensions.gnome.org</Summary>
+        <Description xml:lang="en">Native browser connector for integration with extensions.gnome.org</Description>
+        <Summary xml:lang="tr">extensions.gnome.org ile entegrasyon için yerel tarayıcı bağlayıcısı</Summary>
+        <Description xml:lang="tr">extensions.gnome.org ile entegrasyon için yerel tarayıcı bağlayıcısı</Description>
+        <Archive type="targz" sha1sum="de15855df67b5467b7460fb247485cd0e07ef5e8">https://gitlab.gnome.org/GNOME/gnome-browser-connector/-/archive/v42.0/gnome-browser-connector-v42.0.tar.gz</Archive>
+        <BuildDependencies>
+            <Dependency>meson</Dependency>
+        </BuildDependencies>
+    </Source>
+    
+    <Package>
+        <Name>gnome-browser-connector</Name>
+        <Summary xml:lang="en">Native browser connector for integration with extensions.gnome.org</Summary>
+        <Summary xml:lang="tr">extensions.gnome.org ile entegrasyon için yerel tarayıcı bağlayıcısı</Summary>
+        <Files>
+            <Path fileType="data">/etc</Path>
+            <Path fileType="executable">/usr/bin</Path>
+            <Path fileType="data">/usr/lib</Path>
+            <Path fileType="data">/usr/share</Path>
+            <Path fileType="doc">/usr/share/doc</Path>
+            <Path fileType="icon">/usr/share/icons</Path>
+        </Files>
+    </Package>
+    
+    <History>
+        <Update release="1">
+            <Date>2025-08-16</Date>
+            <Version>48.0</Version>
+            <Comment>Initial build</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
Required to install extensions from GNOME Extensions website.
