### PR TITLE
Package updates

### DIFF
--- a/kernel/drivers/module-linux-apfs-rw/pspec.xml
+++ b/kernel/drivers/module-linux-apfs-rw/pspec.xml
@@ -12,7 +12,7 @@
         <IsA>driver</IsA>
         <Summary>Experimental support for APFS</Summary>
         <Description>The Apple File System (APFS) is the copy-on-write filesystem currently used on all Apple devices. This module provides a degree of experimental support on Linux.</Description>
-        <Archive sha1sum="e8d5288ae46f0b8776d95aa0054865d81ccdcbf4" type="targz">https://github.com/linux-apfs/linux-apfs-rw/archive/refs/tags/v0.3.13.tar.gz</Archive>
+        <Archive sha1sum="6478081f7e199e2d789bdfed67097094976a3fb6" type="targz">https://github.com/linux-apfs/linux-apfs-rw/archive/refs/tags/v0.3.15.tar.gz</Archive>
         <BuildDependencies>
            <Dependency version="6.12.43">kernel-module-headers</Dependency>
         </BuildDependencies>
@@ -33,6 +33,13 @@
     </Package>
 
     <History>
+        <Update release="13">
+            <Date>2025-08-26</Date>
+            <Version>0.3.15</Version>
+            <Comment>Version Bump.</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="12">
             <Date>2025-08-22</Date>
             <Version>0.3.13</Version>

--- a/kernel/tools/apfsprogs/pspec.xml
+++ b/kernel/tools/apfsprogs/pspec.xml
@@ -12,7 +12,7 @@
         <IsA>driver</IsA>
         <Summary>Experimental APFS tools for Linux</Summary>
         <Description>Apfsprogs is a suite of userspace utilities for working with the Apple File System on Linux. It's intended mainly to help test the Linux kernel module, located at https://github.com/linux-apfs/linux-apfs-rw.git</Description>
-        <Archive sha1sum="ebc5bd70ab686cbec7f49d0202d49bddd3784464" type="targz">https://github.com/linux-apfs/apfsprogs/archive/v0.2.0.tar.gz</Archive>
+        <Archive sha1sum="3b9d557c449764cbf671bfb366fb955db3faa611" type="targz">https://github.com/linux-apfs/apfsprogs/archive/v0.2.1.tar.gz</Archive>
     </Source>
 
     <Package>
@@ -28,6 +28,13 @@
     </Package>
 
     <History>
+        <Update release="3">
+            <Date>2025-08-26</Date>
+            <Version>0.2.1</Version>
+            <Comment>Version Bump.</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="2">
             <Date>2024-12-30</Date>
             <Version>0.2.0</Version>

--- a/network/connection/capnet-assist/pspec.xml
+++ b/network/connection/capnet-assist/pspec.xml
@@ -11,7 +11,7 @@
         <License>GPLv3</License>
         <Summary>Captive Network Assistant</Summary>
         <Description>Log into captive portals—like Wi-Fi networks at coffee shops, airports, and trains—with ease. Captive Network Assistant automatically opens to help you get connected.</Description>
-        <Archive sha1sum="0b707cf617a8d948ab9b8ba1d602647dd3a00c48" type="targz">https://github.com/elementary/capnet-assist/archive/8.0.1.tar.gz</Archive>
+        <Archive sha1sum="13f7de8205fee39c341a9da11aa7f6a1725a54ed" type="targz">https://github.com/elementary/capnet-assist/archive/8.0.2.tar.gz</Archive>
         <BuildDependencies>
             <Dependency>gcr-4-devel</Dependency>
             <Dependency>git</Dependency>
@@ -55,6 +55,13 @@
     </Package>
 
     <History>
+        <Update release="3">
+            <Date>2025-08-26</Date>
+            <Version>8.0.2</Version>
+            <Comment>Version Bump.</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="2">
             <Date>2024-12-30</Date>
             <Version>8.0.1</Version>

--- a/network/connection/dnscrypt-proxy/actions.py
+++ b/network/connection/dnscrypt-proxy/actions.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Licensed under the GNU General Public License, version 3.
+# See the file http://www.gnu.org/copyleft/gpl.txt
+
+from pisi.actionsapi import autotools
+from pisi.actionsapi import pisitools
+from pisi.actionsapi import shelltools
+from pisi.actionsapi import get
+
+def build():
+    shelltools.cd("dnscrypt-proxy")
+    shelltools.system("""go build -ldflags "-compressdwarf=false -linkmode external" .""")
+
+def install():
+    # Main executable
+    pisitools.dobin("dnscrypt-proxy/dnscrypt-proxy")
+
+    # Base configuration
+    pisitools.dodir("/etc/dnscrypt-proxy")
+    pisitools.insinto("/etc/dnscrypt-proxy", "dnscrypt-proxy/example-dnscrypt-proxy.toml", "dnscrypt-proxy.toml")
+    pisitools.insinto("/etc/dnscrypt-proxy", "dnscrypt-proxy/example-allowed-ips.txt", "allowed-ips.txt")
+    pisitools.insinto("/etc/dnscrypt-proxy", "dnscrypt-proxy/example-allowed-names.txt", "allowed-names.txt")
+    pisitools.insinto("/etc/dnscrypt-proxy", "dnscrypt-proxy/example-blocked-ips.txt", "blocked-ips.txt")
+    pisitools.insinto("/etc/dnscrypt-proxy", "dnscrypt-proxy/example-blocked-names.txt", "blocked-names.txt")
+    pisitools.insinto("/etc/dnscrypt-proxy", "dnscrypt-proxy/example-captive-portals.txt", "captive-portals.txt")
+    pisitools.insinto("/etc/dnscrypt-proxy", "dnscrypt-proxy/example-cloaking-rules.txt", "cloaking-rules.txt")
+    pisitools.insinto("/etc/dnscrypt-proxy", "dnscrypt-proxy/example-forwarding-rules.txt", "forwarding-rules.txt")
+
+    # generate-domains-blocklist
+    pisitools.dodir("/usr/share/dnscrypt-proxy/utils/generate-domains-blocklist")
+    pisitools.insinto("/usr/share/dnscrypt-proxy/utils/generate-domains-blocklist", "utils/generate-domains-blocklist/*.conf")
+    pisitools.insinto("/usr/share/dnscrypt-proxy/utils/generate-domains-blocklist", "utils/generate-domains-blocklist/*.txt")
+    pisitools.dobin("utils/generate-domains-blocklist/generate-domains-blocklist.py")
+
+    # Documentation
+    pisitools.dodoc("ChangeLog", "README*", "LICENSE*")

--- a/network/connection/dnscrypt-proxy/comar/service.py
+++ b/network/connection/dnscrypt-proxy/comar/service.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from comar.service import *
+import os
+
+serviceType = "local"
+serviceDesc = _({"en": "DNSCrypt-proxy client",
+                 "tr": "DNSCrypt-proxy istemcisi"})
+serviceDefault = "off"
+
+PIDFILE="/run/dnscrypt-proxy.pid"
+
+@synchronized
+def start():
+    # path to executable
+    # creates a pid file, sets the working directory and calls the jar file
+    startService(command="/usr/bin/dnscrypt-proxy",
+                 args="--config /etc/dnscrypt-proxy/dnscrypt-proxy.toml",
+                 donotify=True)
+
+@synchronized
+def stop():
+    stopService(pidfile=PIDFILE,
+                donotify=True)
+
+    try:
+        os.unlink(PIDFILE)
+    except:
+        pass
+
+def ready():
+    start()
+
+def status():
+    return isServiceRunning(pidfile=PIDFILE)

--- a/network/connection/dnscrypt-proxy/pspec.xml
+++ b/network/connection/dnscrypt-proxy/pspec.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "http://www.pisilinux.org/projeler/pisi/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>dnscrypt-proxy</Name>
+        <Homepage>https://github.com/DNSCrypt/dnscrypt-proxy</Homepage>
+        <Packager>
+            <Name>Bedirhan KURT</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Packager>
+        <License>ISC</License>
+        <Summary>Flexible DNS proxy, with support for encrypted DNS protocols</Summary>
+        <Description>A flexible DNS proxy, with support for modern encrypted DNS protocols such as DNSCrypt v2, DNS-over-HTTPS, Anonymized DNSCrypt and ODoH (Oblivious DoH).</Description>
+        <Archive sha1sum="5b21f8b421107cca57dd5ac29ee921b2153b8d5c" type="targz">https://github.com/DNSCrypt/dnscrypt-proxy/archive/refs/tags/2.1.13.tar.gz</Archive>
+        <BuildDependencies>
+            <Dependency>git</Dependency>
+            <Dependency>golang</Dependency>
+        </BuildDependencies>
+    </Source>
+
+    <Package>
+        <Name>dnscrypt-proxy</Name>
+        <RuntimeDependencies>
+            <Dependency>glibc</Dependency>
+            <Dependency>python-urllib3</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="config">/etc/dnscrypt-proxy</Path>
+            <Path fileType="executable">/usr/bin</Path>
+            <Path fileType="doc">/usr/share/doc</Path>
+            <Path fileType="data">/usr/share/dnscrypt-proxy</Path>
+        </Files>
+        <Provides>
+            <COMAR script="service.py">System.Service</COMAR>
+        </Provides>
+    </Package>
+
+    <History>
+        <Update release="1">
+            <Date>2025-08-20</Date>
+            <Version>2.1.13</Version>
+            <Comment>Initial release.</Comment>
+            <Name>Bedirhan KURT</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
+    </History>
+</PISI>
+

--- a/programming/language/go/pspec.xml
+++ b/programming/language/go/pspec.xml
@@ -13,10 +13,10 @@
         <IsA>app:console</IsA>
         <Summary>Compiler and tools for the Go programming language from Google</Summary>
         <Description>Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.</Description>
-        <Archive sha1sum="19f1507e89f926c4d8edd97ca2c8b02158b3ebe8" type="targz">https://github.com/golang/go/archive/refs/tags/go1.23.2.tar.gz</Archive>
+        <Archive sha1sum="d198fbe9623e425eede17f997f2a4c690c21fc3f" type="targz">https://github.com/golang/go/archive/refs/tags/go1.25.0.tar.gz</Archive>
         <!--<Archive sha1sum="6ecdf5a03974462119c051a0d53f825c851ffdbe" type="tarbz2" target="go-go1.14.3">https://dev.gentoo.org/~williamh/dist/go-linux-amd64-bootstrap-1.13.6.tbz</Archive>-->
         <!-- for using as a bootstrap -->
-        <Archive sha1sum="682ecb2fe66c54019f96eb81c4327bf278ce185d" type="targz" target="go-go1.23.2">https://go.dev/dl/go1.23.2.linux-amd64.tar.gz</Archive>
+        <Archive sha1sum="af4c5a9d473463ad4d3de6feaf927c586c76fa89" type="targz" target="go-go1.25.0">https://go.dev/dl/go1.25.0.linux-amd64.tar.gz</Archive>
     </Source>
 
     <Package>
@@ -39,6 +39,13 @@
     </Package>
 
     <History>
+        <Update release="23">
+            <Date>2025-08-20</Date>
+            <Version>1.25.0</Version>
+            <Comment>Version bump</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="22">
             <Date>2024-10-20</Date>
             <Version>1.23.2</Version>

--- a/programming/scm/github-cli/actions.py
+++ b/programming/scm/github-cli/actions.py
@@ -11,10 +11,10 @@ from pisi.actionsapi import get
 def build():
     shelltools.system("go build \
         -trimpath \
-        -ldflags '-extldflags \"%s\" -X github.com/cli/cli/command.Version=v2.73.0 -X github.com/cli/cli/command.BuildDate=2025-05-24' \
+        -ldflags '-extldflags \"%s\" -X github.com/cli/cli/command.Version=v2.78.0 -X github.com/cli/cli/command.BuildDate=2025-08-26' \
         -o 'bin/gh' ./cmd/gh" % get.LDFLAGS())
 
 def install():
-    shelltools.cd("../cli-2.73.0")
+    shelltools.cd("../cli-2.78.0")
     pisitools.insinto("/usr/bin", "bin/gh")
     pisitools.dodoc("LICENSE", "README*")

--- a/programming/scm/github-cli/pspec.xml
+++ b/programming/scm/github-cli/pspec.xml
@@ -14,7 +14,7 @@
         <Summary>GitHub CLI</Summary>
         <Description>"gh" is GitHub on the command line. It brings pull requests, issues, and other GitHub concepts to the terminal next to where you are already working with "git" and your code.</Description>
         <!-- Also bump actions.py while bumping here. -->
-        <Archive sha1sum="82aa6a126a6967f70b09aaca918f2f276cf20374" type="targz">https://github.com/cli/cli/archive/v2.73.0.tar.gz</Archive>
+        <Archive sha1sum="870d7763631526e700dfd9f19af4adb3084ef377" type="targz">https://github.com/cli/cli/archive/v2.78.0.tar.gz</Archive>
         <BuildDependencies>
             <Dependency>golang</Dependency>
         </BuildDependencies>
@@ -34,6 +34,13 @@
     </Package>
 
     <History>
+        <Update release="9">
+            <Date>2025-08-26</Date>
+            <Version>2.78.0</Version>
+            <Comment>Version Bump.</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="8">
             <Date>2025-05-24</Date>
             <Version>2.73.0</Version>

--- a/x11/driver/libva-nvidia-driver/pspec.xml
+++ b/x11/driver/libva-nvidia-driver/pspec.xml
@@ -18,7 +18,7 @@
             <Dependency>libdrm-devel</Dependency>
             <Dependency>libglvnd-devel</Dependency>
         </BuildDependencies>
-        <Archive sha1sum="ed008b026594154041476339874f1baa38c6d43c" type="targz">https://github.com/elFarto/nvidia-vaapi-driver/archive/v0.0.13.tar.gz</Archive>
+        <Archive sha1sum="65b863bfee375d089443ce7c453af0fd18608791" type="targz">https://github.com/elFarto/nvidia-vaapi-driver/archive/v0.0.14.tar.gz</Archive>
     </Source>
 
     <Package>
@@ -38,6 +38,13 @@
     </Package>
 
     <History>
+        <Update release="3">
+            <Date>2025-08-26</Date>
+            <Version>0.0.14</Version>
+            <Comment>Version Bump.</Comment>
+            <Name>Bedirhan KURT</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="2">
             <Date>2024-12-30</Date>
             <Version>0.0.13</Version>


### PR DESCRIPTION
- New package: `dnscrypt-proxy`
- Bump `go`: Required by `dnscrypt-proxy` and new version of `github-cli`.
- Bump `apfsprogs`
- Bump `capnet-assist`
- Bump `github-cli`
- Bump `libva-nvidia-driver`
- Bump `module-linux-apfs-rw`