### PR TITLE
Updates for pinentry

### DIFF
--- a/programming/misc/libassuan/pspec.xml
+++ b/programming/misc/libassuan/pspec.xml
@@ -12,7 +12,7 @@
         <IsA>library</IsA>
         <Summary>IPC library for GnuPG related projects</Summary>
         <Description>This is the IPC library used by GnuPG 2, GPGME and a few other packages.</Description>
-        <Archive sha1sum="93296e2989b0b8e762fbb18399ca41865f2445f3" type="tarbz2">https://www.gnupg.org/ftp/gcrypt/libassuan/libassuan-3.0.0.tar.bz2</Archive>
+        <Archive sha1sum="57fb6f59b1a07e5125115454f5ad4cb0665e0eef" type="tarbz2">https://www.gnupg.org/ftp/gcrypt/libassuan/libassuan-3.0.2.tar.bz2</Archive>
         <BuildDependencies>
             <Dependency>libgpg-error-devel</Dependency>
         </BuildDependencies>
@@ -44,6 +44,13 @@
     </Package>
 
     <History>
+        <Update release="12">
+            <Date>2025-08-26</Date>
+            <Version>3.0.2</Version>
+            <Comment>Version Bump.</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="11">
             <Date>2025-06-16</Date>
             <Version>3.0.0</Version>

--- a/util/crypt/pinentry/pspec.xml
+++ b/util/crypt/pinentry/pspec.xml
@@ -12,7 +12,7 @@
         <IsA>app:console</IsA>
         <Summary>Collection of simple PIN or passphrase entry dialogs which utilize the Assuan protocol</Summary>
         <Description>Pinentry is a collection of simple PIN or passphrase entry dialogs which utilize the Assuan protocol as described by the aegypten project.</Description>
-        <Archive sha1sum="29daaf45f15cb5b8ec9b4a06284343f7a87082fb" type="tarbz2">https://www.gnupg.org/ftp/gcrypt/pinentry/pinentry-1.2.1.tar.bz2</Archive>
+        <Archive sha1sum="ca7c502f347f248377842f7e68df5e971059e4db" type="tarbz2">https://www.gnupg.org/ftp/gcrypt/pinentry/pinentry-1.3.2.tar.bz2</Archive>
         <BuildDependencies>
             <Dependency>gcr-devel</Dependency>
             <Dependency>qt5-base-devel</Dependency>
@@ -36,6 +36,7 @@
             <Path fileType="executable">/usr/bin</Path>
             <Path fileType="info">/usr/share/info</Path>
             <Path fileType="doc">/usr/share/doc</Path>
+            <Path fileType="data">/usr/share/pixmaps/pinentry.png</Path>
         </Files>
         <RuntimeDependencies>
             <!-- <Dependency></Dependency> -->
@@ -109,10 +110,18 @@
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/pinentry-qt</Path>
+            <Path fileType="data">/usr/share/applications/org.gnupg.pinentry-qt5.desktop</Path>
         </Files>
     </Package>
 
     <History>
+        <Update release="8">
+            <Date>2025-08-26</Date>
+            <Version>1.3.2</Version>
+            <Comment>Version Bump.</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="7">
             <Date>2022-11-10</Date>
             <Version>1.2.1</Version>


### PR DESCRIPTION
- **Bump libassuan**: Dependency of pinentry
- **Bump pinentry**: Update from ancient build that requires `libassuan.so.0` which no longer exists
