### PR TITLE
Initial build of hack-fonts-ttf

### DIFF
--- a/desktop/font/hack-fonts-ttf/actions.py
+++ b/desktop/font/hack-fonts-ttf/actions.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Licensed under the GNU General Public License, version 3.
+# See the file http://www.gnu.org/licenses/gpl.txt
+
+from pisi.actionsapi import pisitools
+
+
+def install():
+    pisitools.insinto("/usr/share/fonts/TTF", "build/ttf/Hack-*.ttf")
+    pisitools.insinto("/etc/fonts/conf.avail/45-Hack.conf", "config/fontconfig/45-Hack.conf")
+
+    pisitools.dosym("/etc/fonts/conf.avail/45-Hack.conf", "/etc/fonts/conf.d/45-Hack.conf")
+
+    pisitools.dodoc("LICENSE.md", "README.md")

--- a/desktop/font/hack-fonts-ttf/pspec.xml
+++ b/desktop/font/hack-fonts-ttf/pspec.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<!DOCTYPE PISI SYSTEM "http://www.pisilinux.org/projeler/pisi/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>hack-fonts-ttf</Name>
+        <Homepage>https://sourcefoundry.org/hack/</Homepage>
+        <Packager>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Packager>
+        <License>custom</License>
+        <IsA>data:font</IsA>
+        <Summary xml:lang="en">A hand groomed and optically balanced typeface based on Bitstream Vera Mono.</Summary>
+        <Description xml:lang="en">A hand groomed and optically balanced typeface based on Bitstream Vera Mono.</Description>
+        <Summary xml:lang="tr">Bitstream Vera Mono'yu taban alan bir elle bakımlı ve optik olarak dengeli yazı tipi.</Summary>
+        <Description xml:lang="tr">Bitstream Vera Mono'yu taban alan bir elle bakımlı ve optik olarak dengeli yazı tipi.</Description>
+        <Archive sha1sum="114ca5525dd667559a424b7e38fc2e66f5b35671" type="targz">https://github.com/source-foundry/Hack/archive/refs/tags/v3.003.tar.gz</Archive>
+    </Source>
+
+    <Package>
+        <Name>hack-fonts-ttf</Name>
+        <Files>
+            <Path fileType="config">/etc/fonts</Path>
+            <Path fileType="doc">/usr/share/doc</Path>
+            <Path fileType="data">/usr/share/fonts/TTF</Path>
+        </Files>
+    </Package>
+
+    <History>
+        <Update release="1">
+            <Date>2025-09-04</Date>
+            <Version>3.003</Version>
+            <Comment>Initial release</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
This is the default monospace used in KDE Plasma.
