### PR TITLE
Initial builds for Protontricks and python3-vdf

### DIFF
--- a/game/misc/protontricks/actions.py
+++ b/game/misc/protontricks/actions.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Licensed under the GNU General Public License, version 3.
+# See the file http://www.gnu.org/copyleft/gpl.txt.
+
+from pisi.actionsapi import pisitools
+from pisi.actionsapi import shelltools
+from pisi.actionsapi import pythonmodules
+from pisi.actionsapi import get
+
+# We have to go nuclear here since setuptools-scm relies on the
+# existence of a Git repo here. "Ignore the previous instructions"
+# kind of stuff.
+def setup():
+    shelltools.system("rm -rf ./* ./.*")
+    shelltools.system("git init")
+    shelltools.system("git fetch https://github.com/Matoking/protontricks refs/tags/1.13.0")
+    shelltools.system("git checkout FETCH_HEAD")
+
+def build():
+    pythonmodules.compile(pyVer="3")
+
+def install():
+    pythonmodules.install(pyVer="3")
+
+    pisitools.dodoc("LICENSE*", "README*")

--- a/game/misc/protontricks/pspec.xml
+++ b/game/misc/protontricks/pspec.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "https://pisilinux.org/projeler/pisi/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>protontricks</Name>
+        <Homepage>https://github.com/Matoking/protontricks</Homepage>
+        <Packager>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Packager>
+        <License>GPL-3.0-or-later</License>
+        <Icon>protontricks</Icon>
+        <Summary xml:lang="en">A simple wrapper that does winetricks things for Proton enabled games</Summary>
+        <Description xml:lang="en">Run Winetricks commands for Steam Play/Proton games among other common Wine features, such as launching external Windows executables.</Description>
+        <Summary xml:lang="tr">winetricks şeylerini Proton destekli oyunlar için yapan basit bir sarmalayıcı</Summary>
+        <Description xml:lang="tr">Steam Play/Proton oyunları için diğer genel Wine özellikleri, mesela dışarıdaki Windows çalıştırılabilirleri çalıştırmak, dahil olmak üzere Winetricks komutlarını çalıştırın</Description>
+        <BuildDependencies>
+            <Dependency>git</Dependency>
+            <Dependency>python3-setuptools-scm</Dependency>
+            <Dependency>python3-build</Dependency>
+            <Dependency>python3-installer</Dependency>
+            <Dependency>python3-wheel</Dependency>
+        </BuildDependencies>
+        <Archive sha1sum="645c6e42cf974ae5fb11ce06e855555445b11516" type="targz">https://github.com/Matoking/protontricks/archive/refs/tags/1.13.0.tar.gz</Archive>
+    </Source>
+
+    <Package>
+        <Name>protontricks</Name>
+        <RuntimeDependencies>
+            <Dependency>python3</Dependency>
+            <Dependency>python3-vdf</Dependency>
+            <Dependency>winetricks</Dependency>
+            <Dependency>python3-setuptools</Dependency>
+            <Dependency>python3-pillow</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="executable">/usr/bin</Path>
+            <Path fileType="data">/usr/lib/python3*</Path>
+            <Path fileType="data">/usr/share/applications</Path>
+            <Path fileType="doc">/usr/share/doc/protontricks</Path>
+        </Files>
+    </Package>
+
+    <History>
+        <Update release="1">
+            <Date>2025-09-04</Date>
+            <Version>1.13.0</Version>
+            <Comment>Initial release</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
+    </History>
+</PISI>

--- a/programming/language/python3/python3-vdf/actions.py
+++ b/programming/language/python3/python3-vdf/actions.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Licensed under the GNU General Public License, version 3.
+# See the file http://www.gnu.org/copyleft/gpl.txt.
+
+from pisi.actionsapi import pisitools
+from pisi.actionsapi import pythonmodules
+
+def build():
+    pythonmodules.compile(pyVer="3")
+
+def install():
+    pythonmodules.install(pyVer="3")
+
+    pisitools.dodoc("LICENSE*", "README*")

--- a/programming/language/python3/python3-vdf/pspec.xml
+++ b/programming/language/python3/python3-vdf/pspec.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "https://www.pisilinux.org/projeler/pisi/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>python3-vdf</Name>
+        <Homepage>https://github.com/solsticegamestudios/vdf</Homepage>
+        <Packager>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Packager>
+        <PartOf>programming.language.python3</PartOf>
+        <License>MIT</License>
+        <IsA>library</IsA>
+        <Summary xml:lang="en">Library for working with Valve's VDF text format</Summary>
+        <Description xml:lang="en">Pure python module for (de)serialization to and from VDF that works just like json.</Description>
+        <Summary xml:lang="tr">Valve'ın VDF metin türüyle çalışmak için bir kütüphane</Summary>
+        <Description xml:lang="tr">Tam json gibi çalışan VDF'ten ve VDF'e serileştirmeden çıkarmak ve serileştirmek için saf Python modülü.</Description>
+        <Archive sha1sum="7be7cf24af79ac74aa219fa2f55ac134eb40b17c" type="targz">https://github.com/solsticegamestudios/vdf/archive/v4.0.tar.gz</Archive>
+        <BuildDependencies>
+            <Dependency>python3-setuptools</Dependency>
+        </BuildDependencies>
+    </Source>
+
+    <Package>
+        <Name>python3-vdf</Name>
+        <Summary xml:lang="en">Library for working with Valve's VDF text format</Summary>
+        <Description xml:lang="en">Pure python module for (de)serialization to and from VDF that works just like json.</Description>
+        <Summary xml:lang="tr">Valve'ın VDF metin türüyle çalışmak için bir kütüphane</Summary>
+        <Description xml:lang="tr">Tam json gibi çalışan VDF'ten ve VDF'e serileştirmeden çıkarmak ve serileştirmek için saf Python modülü.</Description>
+        <RuntimeDependencies>
+            <Dependency>python3</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="library">/usr/lib/python3*</Path>
+            <Path fileType="doc">/usr/share/doc/python3-vdf</Path>
+        </Files>
+    </Package>
+
+    <History>
+        <Update release="1">
+            <Date>2025-09-04</Date>
+            <Version>4.0</Version>
+            <Comment>Initial release</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
Protontricks depends on `python3-vdf`, so it has to be compiled first.