### PR TITLE
Fix service for dnscrypt-proxy

### DIFF
--- a/network/connection/dnscrypt-proxy/pspec.xml
+++ b/network/connection/dnscrypt-proxy/pspec.xml
@@ -33,9 +33,19 @@
         <Provides>
             <COMAR script="service.py">System.Service</COMAR>
         </Provides>
+        <AdditionalFiles>
+            <AdditionalFile owner="root" group="root" permission="0755" target="/usr/bin/dnscrypt-proxy-comar-compat.sh">dnscrypt-proxy-comar-compat.sh</AdditionalFile>
+        </AdditionalFiles>
     </Package>
 
     <History>
+        <Update release="2">
+            <Date>2025-09-04</Date>
+            <Version>2.1.13</Version>
+            <Comment>Fixup COMAR service.</Comment>
+            <Name>Bedirhan KURT</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="1">
             <Date>2025-08-20</Date>
             <Version>2.1.13</Version>


### PR DESCRIPTION
I forgot to add the COMAR compat script into AdditionalFiles.
