### PR TITLE
Bump cJSON version to 1.7.19 in pspec.xml

### DIFF
--- a/programming/misc/cjson/pspec.xml
+++ b/programming/misc/cjson/pspec.xml
@@ -12,7 +12,7 @@
         <PartOf>programming.misc</PartOf>
         <Summary>Ultralightweight JSON parser in ANSI C.</Summary>
         <Description>pass</Description>
-        <Archive sha1sum="3e3408c124a2c885e2724ff88d7f5473cda53038" type="targz">https://github.com/DaveGamble/cJSON/archive/v1.7.18/cJSON-1.7.18.tar.gz</Archive>
+        <Archive sha1sum="e66ddd2f99fd321ab53a694e6c74698eb987d056" type="targz">https://github.com/DaveGamble/cJSON/archive/refs/tags/v1.7.19.tar.gz</Archive>
         <BuildDependencies>
             <Dependency>cmake</Dependency>
             <Dependency>ninja</Dependency>
@@ -43,6 +43,13 @@
     </Package>
 
     <History>
+        <Update release="2">
+            <Date>2026-06-06</Date>
+            <Version>1.7.19</Version>
+            <Comment>Version bump to 1.7.19</Comment>
+            <Name>Emir Bayram</Name>
+            <Email>Rimru01@proton.me</Email>
+        </Update>
         <Update release="1">
             <Date>2025-02-06</Date>
             <Version>1.7.18</Version>


### PR DESCRIPTION
Updated the archive link to version 1.7.19 and added release history.