### PR TITLE
packagekit: implement get_categories/get_packages in PiSi backend so …

### DIFF
--- a/desktop/misc/packagekit/files/0002-Add-categories-and-packages.patch
+++ b/desktop/misc/packagekit/files/0002-Add-categories-and-packages.patch
@@ -1,0 +1,84 @@
+diff --git a/backends/pisi/pk-backend-pisi.c b/backends/pisi/pk-backend-pisi.c
+--- a/backends/pisi/pk-backend-pisi.c
++++ b/backends/pisi/pk-backend-pisi.c
+@@ -342,6 +342,21 @@
+ }
+ 
+ void
++pk_backend_get_categories (PkBackend *backend, PkBackendJob *job)
++{
++    pk_backend_spawn_helper (spawn, job, "pisiBackend.py", "get-categories", NULL);
++}
++
++void
++pk_backend_get_packages (PkBackend *backend, PkBackendJob *job, PkBitfield filters)
++{
++    gchar *filters_text;
++    filters_text = pk_filter_bitfield_to_string (filters);
++    pk_backend_spawn_helper (spawn, job, "pisiBackend.py", "get-packages", filters_text, NULL);
++    g_free (filters_text);
++}
++
++void
+ pk_backend_get_repo_list (PkBackend *backend, PkBackendJob *job, PkBitfield filters)
+ {
+ 	gchar *filters_text;
+diff --git a/backends/pisi/pisiBackend.py b/backends/pisi/pisiBackend.py
+--- a/backends/pisi/pisiBackend.py
++++ b/backends/pisi/pisiBackend.py
+@@ -42,6 +42,26 @@
+ import piksemel
+ import re
+ 
++CATEGORY_NAMES = {
++    "system": "System",
++    "security": "Security",
++    "network": "Network",
++    "internet": "Internet",
++    "programming": "Programming",
++    "desktop-gnome": "GNOME Desktop",
++    "desktop-xfce": "Xfce Desktop",
++    "desktop-other": "Desktop",
++    "desktop": "Desktop",
++    "admin-tools": "Administrative Tools",
++    "fonts": "Fonts",
++    "unknown": "Other",
++    "multimedia": "Multimedia",
++    "games": "Games",
++    "office": "Office",
++    "development": "Development",
++}
++
++
+ class SimplePisiHandler(pisi.ui.UI):
+ 
+     def __init(self):
+@@ -175,6 +195,28 @@
+         else:
+             self.error(ERROR_PACKAGE_NOT_FOUND, "Package was not found")
+ 
++    def get_categories(self):
++        """ Emits the list of categories the distribution supports """
++        self.allow_cancel(True)
++        self.percentage()
++
++        seen = set(self.groups.values()) if self.groups else set()
++        seen |= set(CATEGORY_NAMES.keys())
++        for category in sorted(seen):
++            name = CATEGORY_NAMES.get(category,
++                                      category.replace("-", " ").title())
++            self.category(category, category, name, category, None)
++
++    def get_packages(self, filters):
++        """ Emits all packages in the repository database """
++        self.allow_cancel(True)
++        self.percentage()
++        self.status(STATUS_INFO)
++
++        for repo in pisi.api.list_repos():
++            for package in self.packagedb.list_packages(repo):
++                self.__get_package(package, filters)
++
+     def get_files(self, package_ids):
+         """ Prints a file list for a given package """
+         self.allow_cancel(True)

--- a/desktop/misc/packagekit/pspec.xml
+++ b/desktop/misc/packagekit/pspec.xml
@@ -22,6 +22,9 @@
             <Dependency>elogind-devel</Dependency>
             <Dependency>gobject-introspection-devel</Dependency>
         </BuildDependencies>
+	<Patches>
+            <Patch level="1">0002-Add-categories-and-packages.patch</Patch>
+        </Patches>
     </Source>
 
 	<Package>
@@ -76,6 +79,13 @@
     </Package>
 
     <History>
+        <Update release="3">
+            <Date>2026-08-02</Date>
+            <Version>1.1.13</Version>
+            <Comment>Implement get_categories and get_packages in MiSi backend so KDE Discover populates categories and package list.</Comment>
+            <Name>Erkan Işık</Name>
+            <Email>erkan@gmail.com</Email>
+        </Update>
         <Update release="2">
             <Date>2023-11-06</Date>
             <Version>1.1.13</Version>


### PR DESCRIPTION
…KDE Discover works

## Symptom
KDE Discover opened with an empty application list and empty categories.
- pkcon get-categories -> fatal: GetCategories not supported by backend
- pkcon get-packages -> fatal: GetPackages not supported by backend

## Root cause (verified live, three levels)
1. Symbol level: the compiled backend /usr/lib/packagekit-backend/libpk_backend_pisi.so exported pk_backend_search_names, pk_backend_get_updates and pk_backend_get_repo_list, but exported NO pk_backend_get_categories / pk_backend_get_packages.
2. Spawn level: "pkcon search" spawns backends/pisi/pisiBackend.py and works, but get-categories/get-packages never spawn the python helper at all, so the daemon falls through to an unsupported stub.
3. Upstream state: the PiSi backend shipped in the upstream tarball (backends/pisi/*) has no get_categories()/get_packages() implementation, and the existing files/0001-Added-PiSi-support-back.patch is never declared in pspec.xml, so it is never applied during the build either.

## Fix
Add files/0002-Add-categories-and-packages.patch and declare it in pspec.xml (<Patches> element) and bump release 2 -> 3. The patch:

* backends/pisi/pk-backend-pisi.c: add two C forwarders that spawn the python backend, using the exact signatures from src/pk-backend.h:
    - pk_backend_get_categories(PkBackend*, PkBackendJob*) -> spawn "get-categories"
    - pk_backend_get_packages(PkBackend*, PkBackendJob*, PkBitfield) -> spawn "get-packages"
* backends/pisi/pisiBackend.py:
    - get_categories(): derive categories from the /etc/PackageKit/pisi.conf group mapping plus a new CATEGORY_NAMES dictionary, emitting each via self.category().
    - get_packages(filters): iterate every repo via pisi.api.list_repos() and self.packagedb.list_packages(repo), forwarding each package through the existing __get_package() filter handling.

## Verification (host, after reinstalling packagekit 1.1.13-3)
- pkcon get-packages now returns the full repository (thousands of packages, Kurulu + Kullanilabilir) instead of "not supported".
- pkcon get-categories no longer errors.
- libpk_backend_pisi.so now exports the two new symbols; pisiBackend.py contains get_categories()/get_packages() and CATEGORY_NAMES.
- PackageKit runs as a D-Bus activated daemon (/usr/libexec/packagekitd); the daemon is restarted on reinstall to pick up the new backend.

Commands used to verify:
  pisi bi --ignore-sandbox --ignore-safety   (in container, tarball source)
  pisi install -y packagekit-1.1.13-3-p2-x86_64.pisi
  pkcon get-packages / pkcon get-categories