### PR TITLE
libimobiledevice 1.4.0 and new libimobiledevice deps

### DIFF
--- a/hardware/mobile/libimobiledevice-glue/actions.py
+++ b/hardware/mobile/libimobiledevice-glue/actions.py
@@ -5,21 +5,14 @@
 # See the file http://www.gnu.org/licenses/gpl.txt
 
 from pisi.actionsapi import get
-from pisi.actionsapi import autotools
 from pisi.actionsapi import pisitools
+from pisi.actionsapi import autotools
 
 def setup():
-    autotools.autoreconf("-fi")
     autotools.configure("\
                          --disable-static \
                          --disable-silent-rules \
-                         --without-cython \
                         ")
-
-    pisitools.dosed("libtool", " -shared ", " -Wl,-O1,--as-needed -shared ")
-    # Remove rpath
-    pisitools.dosed("libtool", "^hardcode_libdir_flag_spec=.*", "hardcode_libdir_flag_spec=\"\"")
-    pisitools.dosed("libtool", "^runpath_var=LD_RUN_PATH", "runpath_var=DIE_RPATH_DIE")
 
 def build():
     autotools.make()
@@ -27,4 +20,4 @@ def build():
 def install():
     autotools.rawInstall("DESTDIR=%s" % get.installDIR())
 
-    pisitools.dodoc("AUTHORS", "COPYING*", "NEWS", "README*")
+    pisitools.dodoc("COPYING", "NEWS", "README*")

--- a/hardware/mobile/libimobiledevice-glue/pspec.xml
+++ b/hardware/mobile/libimobiledevice-glue/pspec.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "http://www.pisilinux.org/projeler/pisi/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>libimobiledevice-glue</Name>
+        <Homepage>https://github.com/libimobiledevice/libimobiledevice-glue</Homepage>
+        <Packager>
+            <Name>PisiLinux Community</Name>
+            <Email>admins@pisilinux.org</Email>
+        </Packager>
+        <License>LGPLv2+</License>
+        <IsA>library</IsA>
+        <Summary>Library with common code used by the libimobiledevice family of projects</Summary>
+        <Description>libimobiledevice-glue is a library with common code used by libimobiledevice, libusbmuxd and other projects of the family. It provides socket, buffer and base64 helper functions among others.</Description>
+        <Archive sha1sum="68d7a9a270138afe325a8bba321b743ff9222cb3" type="tarbz2">https://github.com/libimobiledevice/libimobiledevice-glue/releases/download/1.3.2/libimobiledevice-glue-1.3.2.tar.bz2</Archive>
+        <BuildDependencies>
+            <Dependency>libplist-devel</Dependency>
+        </BuildDependencies>
+    </Source>
+
+    <Package>
+        <Name>libimobiledevice-glue</Name>
+        <RuntimeDependencies>
+            <Dependency>libplist</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="library">/usr/lib</Path>
+            <Path fileType="doc">/usr/share/doc</Path>
+        </Files>
+    </Package>
+
+    <Package>
+        <Name>libimobiledevice-glue-devel</Name>
+        <Summary>Development files for libimobiledevice-glue</Summary>
+        <RuntimeDependencies>
+            <Dependency release="current">libimobiledevice-glue</Dependency>
+            <Dependency>libplist-devel</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="header">/usr/include</Path>
+            <Path fileType="data">/usr/lib/pkgconfig</Path>
+        </Files>
+    </Package>
+
+    <History>
+        <Update release="1">
+            <Date>2026-08-02</Date>
+            <Version>1.3.2</Version>
+            <Comment>First release (required by libimobiledevice 1.4.0).</Comment>
+            <Name>Erkan Işık</Name>
+            <Email>erkan@gmail.com</Email>
+        </Update>
+    </History>
+</PISI>

--- a/hardware/mobile/libimobiledevice-glue/translations.xml
+++ b/hardware/mobile/libimobiledevice-glue/translations.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<PISI>
+    <Source>
+        <Name>libimobiledevice-glue</Name>
+        <Summary xml:lang="tr">libimobiledevice ailesinin ortak kodu olan kitaplık</Summary>
+        <Description xml:lang="tr">libimobiledevice-glue, libimobiledevice ailesindeki projelerin kullandığı ortak kodu içeren bir kitaplıktır.</Description>
+    </Source>
+
+    <Package>
+        <Name>libimobiledevice-glue-devel</Name>
+        <Summary xml:lang="tr">libimobiledevice-glue için geliştirme dosyaları</Summary>
+    </Package>
+</PISI>

--- a/hardware/mobile/libimobiledevice/pspec.xml
+++ b/hardware/mobile/libimobiledevice/pspec.xml
@@ -14,13 +14,14 @@
         <IsA>app:console</IsA>
         <Summary>Library for connecting to mobile devices</Summary>
         <Description>libimobiledevice is a library for connecting to mobile devices including phones and music players</Description>
-        <Archive sha1sum="9e984960cbb4ad2f6d414894fa027f4f093ea064" type="targz">https://github.com/libimobiledevice/libimobiledevice/archive/1.3.0.tar.gz</Archive>
+        <Archive sha1sum="eb98acec44348bbc68b316cb9e69796bad78886d" type="tarbz2">https://github.com/libimobiledevice/libimobiledevice/releases/download/1.4.0/libimobiledevice-1.4.0.tar.bz2</Archive>
         <BuildDependencies>
-            <Dependency>gnutls-devel</Dependency>
             <Dependency>libusbmuxd-devel</Dependency>
             <Dependency>libplist-devel</Dependency>
-            <Dependency>libtasn1-devel</Dependency>
-            <Dependency>libgcrypt-devel</Dependency>
+            <Dependency>libimobiledevice-glue-devel</Dependency>
+            <Dependency>libtatsu-devel</Dependency>
+            <Dependency>openssl-devel</Dependency>
+            <Dependency>readline-devel</Dependency>
         </BuildDependencies>
         <Patches>
 <!--             <Patch>gnutls-3.4.patch</Patch> -->
@@ -30,11 +31,12 @@
     <Package>
         <Name>libimobiledevice</Name>
         <RuntimeDependencies>
-            <Dependency>gnutls</Dependency>
             <Dependency>libusbmuxd</Dependency>
             <Dependency>libplist</Dependency>
-            <Dependency>libtasn1</Dependency>
-            <Dependency>libgcrypt</Dependency>
+            <Dependency>libimobiledevice-glue</Dependency>
+            <Dependency>libtatsu</Dependency>
+            <Dependency>openssl</Dependency>
+            <Dependency>readline</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib</Path>
@@ -48,11 +50,12 @@
         <Name>libimobiledevice-devel</Name>
         <Summary>Development files for libimobiledevice</Summary>
         <RuntimeDependencies>
-            <Dependency>gnutls-devel</Dependency>
             <Dependency>libusbmuxd-devel</Dependency>
             <Dependency>libplist-devel</Dependency>
-            <Dependency>libtasn1-devel</Dependency>
-            <Dependency>libgcrypt-devel</Dependency>
+            <Dependency>libimobiledevice-glue-devel</Dependency>
+            <Dependency>libtatsu-devel</Dependency>
+            <Dependency>openssl-devel</Dependency>
+            <Dependency>readline-devel</Dependency>
             <Dependency release="current">libimobiledevice</Dependency>
         </RuntimeDependencies>
         <Files>
@@ -62,6 +65,13 @@
     </Package>
 
     <History>
+        <Update release="9">
+            <Date>2026-08-02</Date>
+            <Version>1.4.0</Version>
+            <Comment>Version bump to 1.4.0. New deps: libimobiledevice-glue, libtatsu; libplist 2.7.0; switch TLS backend to OpenSSL (default).</Comment>
+            <Name>Erkan Işık</Name>
+            <Email>erkan@gmail.com</Email>
+        </Update>
         <Update release="8">
             <Date>2020-12-09</Date>
             <Version>1.3.0</Version>

--- a/hardware/mobile/libplist/actions.py
+++ b/hardware/mobile/libplist/actions.py
@@ -9,19 +9,14 @@ from pisi.actionsapi import pisitools
 from pisi.actionsapi import autotools
 
 def setup():
-    #  do not link with installed old library
-    pisitools.dosed("cython/Makefile.*", "(plist_la_LDFLAGS\s=.*)(\s-L\$\(libdir\))(.*)", r"\1\3")
-    autotools.autoreconf("-fiv")
-
     autotools.configure("\
                          --disable-static \
                          --disable-silent-rules \
+                         --without-cython \
                         ")
 
-    pisitools.dosed("libtool", " -shared ", " -Wl,-O1,--as-needed -shared ")
-
 def build():
-    autotools.make("-j1")
+    autotools.make()
 
 def install():
     autotools.rawInstall("DESTDIR=%s" % get.installDIR())

--- a/hardware/mobile/libplist/pspec.xml
+++ b/hardware/mobile/libplist/pspec.xml
@@ -14,21 +14,11 @@
         <IsA>app:console</IsA>
         <Summary>Library for manipulating Apple Binary and XML Property Lists</Summary>
         <Description>libplist is a library for manipulating Apple Binary and XML Property Lists.</Description>
-        <Archive sha1sum="a92830a3286442f9ea2eac02db81fcfb149a0812" type="tarbz2">http://www.libimobiledevice.org/downloads/libplist-2.2.0.tar.bz2</Archive>
-        <BuildDependencies>
-            <Dependency>libxml2-devel</Dependency>
-            <Dependency>python-devel</Dependency>
-            <Dependency>cython</Dependency>
-        </BuildDependencies>
+        <Archive sha1sum="7d7bf7385c48086eda903975bf45d4f5178b3481" type="tarbz2">https://github.com/libimobiledevice/libplist/releases/download/2.7.0/libplist-2.7.0.tar.bz2</Archive>
     </Source>
 
     <Package>
         <Name>libplist</Name>
-        <RuntimeDependencies>
-            <Dependency>libxml2</Dependency>
-            <Dependency>python</Dependency>
-            <Dependency>libgcc</Dependency>
-        </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib</Path>
             <Path fileType="doc">/usr/share/doc</Path>
@@ -42,8 +32,6 @@
         <Summary>Development files for libplist</Summary>
         <RuntimeDependencies>
             <Dependency release="current">libplist</Dependency>
-            <Dependency>libxml2-devel</Dependency>
-            <Dependency>python-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include</Path>
@@ -52,6 +40,13 @@
     </Package>
 
     <History>
+        <Update release="8">
+            <Date>2026-08-02</Date>
+            <Version>2.7.0</Version>
+            <Comment>Version bump to 2.7.0 (required by libimobiledevice 1.4.0 / libtatsu 1.0.5). Build without Cython bindings; drop obsolete libxml2/python deps.</Comment>
+            <Name>Erkan Işık</Name>
+            <Email>erkan@gmail.com</Email>
+        </Update>
         <Update release="7">
             <Date>2020-06-24</Date>
             <Version>2.2.0</Version>

--- a/hardware/mobile/libtatsu/actions.py
+++ b/hardware/mobile/libtatsu/actions.py
@@ -5,21 +5,14 @@
 # See the file http://www.gnu.org/licenses/gpl.txt
 
 from pisi.actionsapi import get
-from pisi.actionsapi import autotools
 from pisi.actionsapi import pisitools
+from pisi.actionsapi import autotools
 
 def setup():
-    autotools.autoreconf("-fi")
     autotools.configure("\
                          --disable-static \
                          --disable-silent-rules \
-                         --without-cython \
                         ")
-
-    pisitools.dosed("libtool", " -shared ", " -Wl,-O1,--as-needed -shared ")
-    # Remove rpath
-    pisitools.dosed("libtool", "^hardcode_libdir_flag_spec=.*", "hardcode_libdir_flag_spec=\"\"")
-    pisitools.dosed("libtool", "^runpath_var=LD_RUN_PATH", "runpath_var=DIE_RPATH_DIE")
 
 def build():
     autotools.make()
@@ -27,4 +20,4 @@ def build():
 def install():
     autotools.rawInstall("DESTDIR=%s" % get.installDIR())
 
-    pisitools.dodoc("AUTHORS", "COPYING*", "NEWS", "README*")
+    pisitools.dodoc("COPYING", "NEWS", "README*")

--- a/hardware/mobile/libtatsu/pspec.xml
+++ b/hardware/mobile/libtatsu/pspec.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "http://www.pisilinux.org/projeler/pisi/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>libtatsu</Name>
+        <Homepage>https://github.com/libimobiledevice/libtatsu</Homepage>
+        <Packager>
+            <Name>PisiLinux Community</Name>
+            <Email>admins@pisilinux.org</Email>
+        </Packager>
+        <License>LGPLv2+</License>
+        <IsA>library</IsA>
+        <Summary>Library handling the communication with Apple's TSS (Tatsu) servers</Summary>
+        <Description>libtatsu is a library handling the communication with Apple's TSS (Tatsu) servers, used for example for SHSH/APTicket blobs.</Description>
+        <Archive sha1sum="29de7d83a0ece8252feaed7e93df7b4a604577e9" type="tarbz2">https://github.com/libimobiledevice/libtatsu/releases/download/1.0.5/libtatsu-1.0.5.tar.bz2</Archive>
+        <BuildDependencies>
+            <Dependency>libplist-devel</Dependency>
+            <Dependency>curl-devel</Dependency>
+        </BuildDependencies>
+    </Source>
+
+    <Package>
+        <Name>libtatsu</Name>
+        <RuntimeDependencies>
+            <Dependency>libplist</Dependency>
+            <Dependency>curl</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="library">/usr/lib</Path>
+            <Path fileType="doc">/usr/share/doc</Path>
+            <Path fileType="executable">/usr/bin</Path>
+            <Path fileType="man">/usr/share/man/man1</Path>
+        </Files>
+    </Package>
+
+    <Package>
+        <Name>libtatsu-devel</Name>
+        <Summary>Development files for libtatsu</Summary>
+        <RuntimeDependencies>
+            <Dependency release="current">libtatsu</Dependency>
+            <Dependency>libplist-devel</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="header">/usr/include</Path>
+            <Path fileType="data">/usr/lib/pkgconfig</Path>
+        </Files>
+    </Package>
+
+    <History>
+        <Update release="1">
+            <Date>2026-08-02</Date>
+            <Version>1.0.5</Version>
+            <Comment>First release (required by libimobiledevice 1.4.0).</Comment>
+            <Name>Erkan Işık</Name>
+            <Email>erkan@gmail.com</Email>
+        </Update>
+    </History>
+</PISI>

--- a/hardware/mobile/libtatsu/translations.xml
+++ b/hardware/mobile/libtatsu/translations.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<PISI>
+    <Source>
+        <Name>libtatsu</Name>
+        <Summary xml:lang="tr">Apple TSS sunucularıyla iletişimi yöneten kitaplık</Summary>
+        <Description xml:lang="tr">libtatsu, Apple'ın TSS (Tatsu) sunucularıyla iletişimi yöneten bir kitaplıktır.</Description>
+    </Source>
+
+    <Package>
+        <Name>libtatsu-devel</Name>
+        <Summary xml:lang="tr">libtatsu için geliştirme dosyaları</Summary>
+    </Package>
+</PISI>

--- a/hardware/mobile/libusbmuxd/pspec.xml
+++ b/hardware/mobile/libusbmuxd/pspec.xml
@@ -14,7 +14,7 @@
         <IsA>library</IsA>
         <Summary>Daemon for communicating with Apple's iPod Touch and iPhone</Summary>
         <Description>libusbmuxd is a daemon used for communicating with Apple's iPod Touch and iPhone devices. It allows multiple services on the device to be accessed simultaneously.</Description>
-        <Archive sha1sum="e3c2c846471ba7c171c01d87cb37d379d53d5f02" type="tarbz2">http://www.libimobiledevice.org/downloads/libusbmuxd-2.0.2.tar.bz2</Archive>
+        <Archive sha1sum="e3c2c846471ba7c171c01d87cb37d379d53d5f02" type="tarbz2">https://github.com/libimobiledevice/libusbmuxd/releases/download/2.0.2/libusbmuxd-2.0.2.tar.bz2</Archive>
         <BuildDependencies>
             <Dependency>libplist-devel</Dependency>
             <Dependency>libusb-devel</Dependency>
@@ -50,6 +50,13 @@
     </Package>
 
     <History>
+        <Update release="5">
+            <Date>2026-08-02</Date>
+            <Version>2.0.2</Version>
+            <Comment>Rebuild against libplist 2.7.0.</Comment>
+            <Name>Erkan Işık</Name>
+            <Email>erkan@gmail.com</Email>
+        </Update>
         <Update release="4">
             <Date>2020-06-24</Date>
             <Version>2.0.2</Version>


### PR DESCRIPTION
- libimobiledevice 1.3.0 -> 1.4.0; TLS backend switched to OpenSSL (default) instead of GnuTLS. Requires libimobiledevice-glue and libtatsu.
- libplist 2.2.0 -> 2.7.0 (needed by libtatsu >= 2.6.0 and libimobiledevice); build without Cython, drop obsolete libxml2/python deps.
- libusbmuxd 2.0.2 rebuilt against libplist 2.7.0 (release 5); fixed dead download URL (libimobiledevice.org -> GitHub release).
- Add new packages libimobiledevice-glue 1.3.2 and libtatsu 1.0.5.