### PR TITLE
solid: rebuild against libplist 2.7.0 and libimobiledevice 1.4.0 (rel…

### DIFF
--- a/desktop/kde/framework/solid/pspec.xml
+++ b/desktop/kde/framework/solid/pspec.xml
@@ -72,6 +72,13 @@
     </Package>
 
     <History>
+        <Update release="90">
+            <Date>2026-08-02</Date>
+            <Version>6.28.0</Version>
+            <Comment>Rebuild against libplist 2.7.0 and libimobiledevice 1.4.0 (SONAME bump libplist-2.0.so.3 -> .so.4).</Comment>
+            <Name>Erkan Işık</Name>
+            <Email>erkan@gmail.com</Email>
+        </Update>
         <Update release="89">
             <Date>2026-07-10</Date>
             <Version>6.28.0</Version>


### PR DESCRIPTION
…ease 90)

libplist SONAME bumped 2.0.so.3 -> .so.4 with the 2.7.0 update; solid's libKF6Solid still linked the old .so.3, breaking systemsettings and any other KDE app loading Solid. Rebuild fixes the ABI link.