### PR TITLE
Update fastfetch to version 2.66.0

### DIFF
--- a/util/misc/fastfetch/pspec.xml
+++ b/util/misc/fastfetch/pspec.xml
@@ -28,7 +28,7 @@
             <Dependency>xfconf-devel</Dependency>
             <Dependency>zlib-devel</Dependency>
         </BuildDependencies>
-        <Archive sha1sum="689e3059cd6fb20bfd9fab1970eaf56fb5f2546a" type="targz">https://github.com/fastfetch-cli/fastfetch/archive/2.51.1.tar.gz</Archive>
+        <Archive sha1sum="76105cab96ea1eda1b83e98f34707535acc5ec43" type="targz">https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.66.0.tar.gz</Archive>
     </Source>
     <Package>
         <Name>fastfetch</Name>
@@ -64,6 +64,13 @@
         </Files>
     </Package>
     <History>
+        <Update release="2">
+            <Date>2026-08-04</Date>
+            <Version>2.66.0</Version>
+            <Comment>Version bump.</Comment>
+            <Name>Emir Bayram</Name>
+            <Email>rimru01@proton.me</Email>
+        </Update>
         <Update release="1">
             <Date>2025-08-31</Date>
             <Version>2.51.1</Version>


### PR DESCRIPTION
Updated the archive link to version 2.66.0 and added a new update entry in the history.